### PR TITLE
enable multiple top-level elements in templates; document macos dylib arch exploration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,9 +674,9 @@ dependencies = [
 
 [[package]]
 name = "include_dir"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "482a2e29200b7eed25d7fdbd14423326760b7f6658d21a4cf12d55a50713c69f"
+checksum = "18762faeff7122e89e0857b02f7ce6fcc0d101d5e9ad2ad7846cc01d61b7f19e"
 dependencies = [
  "glob",
  "include_dir_macros",

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ at your option.
 Use `rustc` 1.65.0 via `rustup`
 
 
-### Optional environment setup, web chassis
+### Environment setup, building for Web
 
 - Install `wasm-opt` via `binaryen`:
    ```shell
@@ -129,7 +129,7 @@ Use `rustc` 1.65.0 via `rustup`
   npm i --global yarn
    ```
 
-### Optional environment setup, macOS chassis
+### Environment setup, building for macOS
 
 - Install xcode, command line utils
 

--- a/backlog-archive.md
+++ b/backlog-archive.md
@@ -1,0 +1,765 @@
+**IMPORTANT NOTE:** management of list has been migrated to an external task tracker as of February 2023.
+This historic "one-person tracker" remains as reference, and its contents are not authoritative or up-to-date.
+
+## Milestone: proof of concept engine
+
+```
+[x] Rendering 
+[x] Components 
+[x] Logging
+[x] Stroke, color, fill
+[x] Sizing
+    [x] Browser resize support
+    [x] None-sizing
+    [x] Transform.align
+    [x] Transform.anchor
+[x] Expression engine
+    [x] variables, declaration & storage
+    [x] node IDs
+    [x] summonables
+    [x] built-in vars like frame count
+    [x] MVP rust closures + manifest of deps
+[x] Stackers (née Stacks)
+    [x] Decide `primitive` vs. userland `components`
+    `components`
+    [x] Internal template mechanism for components
+    [x] Make `root` into a component definition
+    [x] Control-flow `slot` (`slot`) for inputs/children
+    [x] Ensure path forward to userland `slots`
+    [x] Clipping & Frames
+    [x] Control-flow `repeat` for cells & dividers inside template
+    [x] Gutter
+[x] Split out userland code
+    [x] Add a third project to workspace, the sample project
+    [x] (Further work to be done via compiler task)
+[x] Timelines, transitions
+[x] Refactors
+    [x] Bundle Transform into "sugary transform," incl. anchor & align; consider a separate transform_matrix property
+    [x] Is there a way to better-DRY the shared logic across render-nodes?
+e.g. check out the `get_size` methods for Frame and Stacker
+    [x] Maybe related to above:  can we DRY the default properties for a render node?
+Perhaps a macro is the answer?
+    Same with `scale`
+    [x] Can we do something better than `(Box<......>, Box<.......>)` for `Size`?
+    [x] Rename various properties, e.g. bounding_dimens => bounds
+    [x] Take a pass on references/ownership in render_render_tree — perhaps &Affine should transfer ownership instead, for example
+    [x] Better ergonomics for `wrap_render_node_ptr_into_list`
+    [x] Evaluate whether to refactor the `unsafe` + PolymorphicType/PolymorphicData approach in expressions + scope data storage
+```
+
+## Milestone: Stacker
+
+```
+[x] decide on API design, expected GUI experience
+    - Direction (horiz/vert)
+    - Gutter
+    - Cell widths
+[x] expose a Stacker element for consumption by engine
+[x] accept children, just like primitives e.g. `Group`
+[x] author an internal template, incl. `slot`ing children and `repeating` inputs
+    <Frame repeat=self.children transform=get_transform(i)>
+        <Slot index=i>
+    </Frame>
+    - need to be able to define/call methods on containing class (a la VB)
+    - need to figure out polymorphism, Vec<T> (?) for repeat
+    - need to figure out slot — special kind of rendernode?
+[x] Frame
+    [x] Clipping
+[x] Slot
+[x] Repeat
+    [x] "flattening yield" to support <Stacker><Repeat n=5><Rect>...
+    [x] scopes:
+        [x] `i`, `datum`
+        [x] braced templating {} ? or otherwise figure out `eval`
+            - Code-gen?  piece together strings into a file and run rustc on it?
+            * Can achieve this with Expressions for now
+        [x] calling "class methods" from templates, e.g. <Repeat n=5><Rect color="get_color(i)"
+            * Can achieve with expressions
+[x] Scopes & DI
+    [x] Figure out dissonance between:  1. string based keys, 2. struct `Properties`
+        and figure out how this plays out into the property DI mechanism.  Along the way,
+        figure out how to inject complex objects (ideally with a path forward to a JS runtime.)
+            - Option A:  write a macro that decorates expression definitions (or _is_ the exp. def.) and (if possible)
+                         generates the necessary code to match param names to elsewhere-registered dependency streams (Angular-style)
+            - Option A0: don't write the macro (above, A) yet, but write the expanded version of it by hand, incl. string deps (present-day approach)
+                         ^ to achieve "DI," does this require a hand-rolled "monomorphization" of each expression invocation?
+                         Or does a string dependency list suffice?  If the latter, we must solve a way to pass a data-type <D> through PolymorphicValue
+                         Probably the answer is the _former_ — write the DI-binding logic manually alongside a string dep list (roughly how the macro unrolling will work)
+    [x] Support getting self (or Scope) for access to Repeat Data
+        - use-case: translate each element within a `repeat` by `i * k`
+    [x] Quick pass on other relevant data to get from Scopes
+[x] Layout
+    [x] Primary logic + repeat via expression
+    [x] Parameterize:
+        - Gutter
+        - (come back later for overrides; ensure design supports visual UX)
+```
+
+## Milestone: expressive RIL, hand-written
+
+_RIL means Rust Intermediate Language, which is the
+"object code" — i.e. compiler backend target — for Pax.  As the name suggests, RIL is valid Rust
+(specifically, a subset of Rust.)  Pax relies on
+`rustc` (via `cargo`) to convert RIL "object code" to machine code._
+
+```
+[x] Compile base cartridge
+    [x] Refactor PropertiesCoproduct to its own module
+    [x] Sanity check "patch" ability for "blanks" (Properties, Expressions)
+    [x] Demo app chassis running example project (`./serve.sh`)
+        [x] Add stub macro for `pax`, derives
+[x] baseline primitive(s) for hello world
+    [x] import/package management
+    [x] RIL -> PAX compatibility, port primitives
+        [x] Repeat, path from @foreach
+[x] hand-write RIL first!
+    [x] Handle control-flow with codegen
+        [x] support with manual RIL, port old primitives
+            [x] @for
+                [x] syntax
+                [x] with/out enumeration (`i`)
+                [x] figure out scoping, e.g. addition of symbols to namespace, collision management
+                [x] RepeatItem: manage scope, properties
+            [x] @if
+            [x] slot
+            [x] frame
+    [x] rendering hello world
+    [x] proof of concept (RIL) for expressions
+    [x] handle expressable + nestable, e.g. Stroke (should be able to set root as Expression, or any individual sub-properties)
+    [x] proof of concept (RIL) for timelines
+        [x] running on assumption that the problem is isomorphic to the Expression vtable problem
+    [x] proof of concept (RIL) for actions
+        [x] pax::log
+        [x] `Tick` support (wired up)
+        [x] pencil in `Click`, but don't worry about raycasting yet (or do naive raycasting?? easy to PoC!)
+        [x] sanity-check Repeat
+    [x] port Repeat, etc. to latest RIL
+[x] API cleanup pass
+    [x] make consistent Size, Percent, Anchor, Align
+    [x] finish-line @if
+    [x] support in-.rs-file pax, as alternative choice vs. code-behind file
+```
+
+## Milestone: imported .pax
+
+```
+[x] Spend some cycles ideating demo deliverables/storyboard
+[x] Port Stacker to be a pure component
+    [x] figure out importing mechanism for core and/or other std primitives
+        [x] Group, Slot (e.g. from Core)
+        [x] Frame (e.g. from std — though if easier could just move to Core)
+    [x] port stacker logic; design expression/method approach
+        [-] pure expressions + helpers?
+        [x] on_will_render + manual dirty checking?
+            [x] decision: no dirty checking at all for right now; expose imperative dirty-check API only when implementing dirty checking for Expressions
+    [x] hook in existing layout calc logic
+[x] Import and use Stacker in Root example
+    [x] update example .pax as needed along the way
+    [x] "expand the proof" of generated code & make it work manually
+```
+
+
+## Milestone: clickable square
+
+```
+[x] Action API
+    [x] state management (.get/.set/etc.)
+    [-] hooks into dirty-update system, to support expression dirty-watching
+    [x] Instantiation, reference management, enum ID + addressing for method definitions &
+        invocations
+    [x] tween/dynamic timeline API
+[x] revisit chassis-web implementation
+    [x] rust/JS divide
+        [x] Sandwich TS and rust (as current,) or
+        [x] handle all cartridge work from rust, incl. generation of public API
+[x] Event capture and transmission
+    [x] Map inputs through chassis, native events (mouse, touch)
+        [x] PoC with Web
+        [x] PoC with macOS
+    [x] tick event e2e
+    [x] Message queue in runtime
+    [x] Ray-casting? probably
+    [x] Message bubbling/capture or similar solution
+[x] Expressions
+    [x] Write ExpressionTable harness, incl. mechanisms for:
+        [x] vtable storage & lookup
+        [x] Return value passing & caching
+    [-] Sketch out design for parallelized expression computation (e.g. in WebWorkers)
+    [-] Patch ExpressionTable into cartridge à la PropertyCoproduct
+```
+
+
+## Milestone: Eureka
+
+```
+[x] resolve the `Any` question
+    [x] defer until later; reassess if it becomes clear a lot of backtracking is emerging 
+[x] parser
+    [x] grammar definition, PEG
+    [x] parse grammar into manifest
+[x] grammar/parser updates:
+    [x] `@for`
+    [x] ranges: literal and symbolic
+    [x] `@template` block, vs. top-level
+[x] native rendering ++
+    [x] message design/arch
+    [x] runtime de/serialization
+        [x] Data across FFI
+            [x] explore raw C structs (decided: brittle)
+            [x] Logging, strings, message-passing
+            [x] CRUD operations and methods: PoC with `Text`
+            [x] flexbuffers instead of fat c structs
+                - Might want to revisit one day for fixed schema, might reduce Swift boilerplate?
+    [x] ids
+        [x] handle monotonic, instance-unique IDs
+            - expose method in engine to generate new id
+            - initial use-case: instance IDs for associating engine <> native Text instances
+    [x] text support
+        [x] handle_did_mount and handle_will_unmount
+        [x] trigger mount/unmount lifecycle events in engine, `Conditional`, `Repeat`
+        [x] hook up Text primitive + API
+            [x] macOS
+            [x] web -- reattach with updated messaging model
+            [x] basic API pass: content, color, font, textSize
+        [x] handle dirty-checking for `Patch` event population
+    [x] native clipping support
+        [x] rectilinear-affine frames
+        [x] support macOS
+        [x] support Web
+    [x] click support
+        [x] simple 2D ray-casting
+            [x] Handle clipped content? and scrolled content? (i.e. check within accumulated clip bounds as well as object bounds)
+        [x] inbound event arg-wrapping and dispatch
+            [x] macos
+            [x] web
+        [x] sketch out bubbling/canceling, hierarchy needs
+[x] dev env ++
+    [x] support for different example projects
+    [x] native macOS chassis + dev-harness
+        [x] pax-chassis-macos (written in rust). responsible for:
+            [x] accepting a CGContext pointer and rendering to it via Piet
+            [x] managing user input channel, e.g. click/touch
+            [x] managing native rendering channel, e.g. form controls, text
+        [x] mac app dev-harness (written in swift). responsible for:
+            [x] granting a piece of real estate (full window of simple mac app) to rendering with a CGContext.
+            [x] passing CGContext to pax-chassis-coregraphics
+            [x] handling resize
+            [x] handling basic user input (e.g. click)
+        [x] Debugging via LLDB
+            [x] support debugging as necessary with macos dev-harness
+            [x] IDE configs for each of: userland cartridge; core; std
+[x] compiler + codegen
+    [-] codegen Cargo.toml + solution for patching
+    Note: decided to require manual Cargo setup for launch (solved by `generate` use-case)
+        [x] manual
+        [-] automated + file generation
+        [-] Note use-case: pax-std also needs the same feature flags + deps.  Would be nice to automate!
+    [x] .pax folder
+        [x] manual .pax folder 'proof'
+        [x] codegen + templating logic
+    [x] generate `pub mod pax_reexports` via `pax_app` -- tricky because full parse is required to
+        know how to build this tree.  Either: do a full parse during macro eval (possible! pending confirmation that parse_to_manifest can be called at macro-expansion time) or
+        do some codegen/patching on the userland project (icky)
+        (Tentative decision: refactor macro-time parse logic; probably do a full parse; return necessary dep strings along with pascal_identifiers)
+        Escape hatch if the above doesn't work: use include_str!() along with a file that contains
+        [x] Refactor parsing logic -- maybe start clean?
+            [x] De-risk: verify ability to call macro-generated code at compile-time (parse_to_manifest)
+            [x] Parse all of, recursively:
+                [x] Template
+                [x] Properties:
+                    [x] Property key
+                    [x] Property type, full module (import) path
+                        [x] This will be tricky... either
+                            [-] static analysis on the whole source file, looking for a `use ... KEYWORD` statement and infer paths
+                            [-] dynamic analysis -- some kind of rustc API.....?
+                            [x] dynamic analysis: `parse_to_manifest`-style `get_module_path`, called by parser
+                                [x] parser returns fully qualified types in manifest by dynamically calling `get_module_path` on each discovered type during parsing
+                                [x] refactor: punch `parser` features through all necessary Cargo.tomls — `impl PropertyManifestable` manually for `Size` and `Size2D`
+                                [-] refactor: instead of `scoped_resolvable_types`, might need to `impl PropertyManifestable` for concrete nested generic types, e.g.
+                                    instead of Vec::get_property_manifest and Rc::get_property_manifest, Vec<Rc<StackerCell>>::get_property_manifest
+                                    -- this addresses compiler error `cannot infer type T for Rc<T>` (non-viable approach)
+                                        [x] Alternatively: hard-code a list of prelude types; treat as blacklist for re-exporting
+                                            -- note that this adds additional complexity/weakness around "global identifier" constraints, i.e. that as currently implemented, there can be no userland `**::**::Rc` or `**::**::Vec`  
+                            [-] Require fully qualified types inside Property<...>, like `Property<crate::SomeType>` or `Property<pax::api::Color>`  
+                            [-] Make Property types `Pathable` or similar, which exposes a method `get_module_path()` that invoked `module_path!()` internally
+                                Then -- `pax` macro can invoke `get_module_path()` just like `parse_to_manifest`
+                                (Evaluated at compiletime) `Color::_get_module_path()`
+                                    ^ wrong -- this would be evaluated at `parser bin`-time
+                                Which returns `pax_runtime_api::Color`
+                                Which gets codegenned into `pub mod pax_reexports`
+                                Checksum: does this resolve at the right time
+                                MAYBE we still need two phases:  one that parses template and property types, which allows codegen of `get_module_path` and `parse_to_manifest`
+                                                                 and another that runs the parser bin
+        [x] Codegen`.pax/reexports.partial.rs`
+            [x] Basic logic
+            [x] Filter prelude
+            [x] fix bug: using `ctx` for property_manifests (maybe only a bug in primitives)
+            [x] Hook up primitives + types
+                -- possibly recycle logic that checks for `Property<...>`
+            [x] fix bug: prelude types not showing up in PropertyManifests
+                -- perhaps each propertymanifest should have:
+                    -- fully qualified atomic types
+                        -- for `pub mod pax_reexports`
+                        -- for recursive calls to `get_property_manifest`
+                        -- for TypesCoproduct generation
+                        -- for cartridge codegen (imports)
+                    -- In each of the above, it should be reasonable to handle prelude vs. imported types separately
+                    -- Also: should this be called something else, like `dependencies` or `imports`? Instead of `PropertyManifests`.
+                    -- What about `properties`?  For design tooling, will definitely be necessary.  Is it worth shimming `dependencies` into 
+                       -- maybe `get_property_manifest` should just be `get_property_dependencies` ??
+        [-] include_str!() `.pax/reexports.partial.rs` _at compile-time_ in macro logic
+            -- the goal is for this types re-export to be present at the root of the *userland project* by the time
+            the chassis is attached / compiled
+            [-] might need to "create if doesn't exist," or otherwise guard the lifecycle of the include_str! per best practice
+                -- a likely-viable approach: feature-gate two complementary `pax_app` macros, across binary values `is parser`
+                   parser mode passes an empty string; prod mode assumes presence of .pax/reexports.partial.rs and hard-code-includes it
+            [x] solution: write another macro, gated behind `not(feature="parser")`, which gets
+                passed `env!("CARGO_MANIFEST_DIR")`
+    [x] parser bin logic finish-line
+        [x] macro
+    [X] untangle dependencies between core, runtime entities (e.g. Transform, RenderTreeContext, RenderNodePtrList), and cartridge
+    [X] work as needed in Engine to accept external cartridge (previously where Component was patched into Engine)
+    [x] update .pest and manifest-populating logic to latest language spec
+    [x] support incremental compilation — not all #[pax] expansions (namely, side-effects) are expected to happen each compilation
+        [-] NOTE: provisionally, this whole group is solved as not necessary, in light of the "parser binary" feature-flagged approach
+        [x] science: determine how macros behave, caching of expansion, incremental compilation
+        [x] allow macros to report their registrants and the appropriate module path + file path via IPC
+        [x] sweep for files that have been removed from fs; update fsdb
+        [x] determine
+        [x] persist fsdb to disk, probably .pax/fsdb, probably binpack
+        [x] enable manual full rebuild, e.g. via `pax compile --full | --force | etc.` (should be doable via rustc with something like INCREMENTAL=0, refer to rust incremental compilation docs)
+    [x] architecture
+        [x] compiler seq. diagram 
+        [x] dependency diagram
+    [x] two-stage compilation process
+        [x] thread/process/IPC chassis
+        [x] parser cargo feature
+        [x] bin-running harness to execute parser (see https://stackoverflow.com/questions/62180215/renaming-main-rs-and-using-with-cargo)
+        [-] TCP message passing (using stdio for now)
+            [x] de/serialization for manifest
+                [x] maybe normalize SelectorLiteralBlockDefinitions, if Serde can't elegantly de/serialize it
+                [x] or de-normalize TemplateNodeDefinition!
+            [-] coordination of TCP client/server from compiler main thread
+        [x] parse and load .pax files
+            [x] load file via macro
+            [x] generate the parser bin logic via macro
+                [x] manual
+            [x] port minimal set of std entities (Rectangle, Group) to support manifest-gen 
+            [x] traverse manifest of Component defs: parse .pax files, store in mem
+            [x] (start with templates only)
+    [x] thread for wrapping `cargo build`
+    [x] sketch out .pax folder design
+    [-] graceful shutdown for threaded chassis (at least: ctrl+c and error handling)
+        [x] Alternatively: back out of async, given stdio for passing data from parser 
+    [x] generate & embed reexports
+        [x] parse properties into manifest
+        [x] bundle pax_reexports into nested mods
+        [x] load reexports.partial.rs into userland project
+    [x] introduce `pax-cli`, import compiler to be a dep
+        [-] `pax demo`?
+        [-] `pax create` 
+    [x] generate properties coproduct
+        [x] retrieve userland crate name (e.g. `pax-example`) and identifier (e.g. `pax_example`) 
+            [-] alternatively, hard-code a single dependency, something like "host", which always points to "../.." (relative to ".pax/properties-coproduct")
+                -- don't think the above will work; cargo needs a symbol that maps to the target Cargo.toml
+        [x] patch / generate Cargo.toml
+            [x] include `pax-example = {path="../../"}`
+                -- where `pax-example` is the userland crate name
+        [x] PropertiesCoproduct
+            -- coproduct of ComponentName
+            [x] run through Tera template, iterating over dependencies
+        [x] TypesCoproduct
+            -- coproduct of all types from PropertyDefinitions 
+            [x] if necessary, supporting type parsing & inference work for TypesCoproduct
+            [x] run through Tera template
+    [x] generate cartridge definition
+        [x] prelude / hard-coded template
+        [x] imports via `pax_example::pax_reexports::*`
+            -- or, fully resolve every import when using
+        [x] component factories
+            [x] `compute_properties_fn` generation
+            [x] `instantiate_root_component` generation, based on `pax_root` declaration
+            [x] `properties: PropertiesCoproduct::Stacker(Stacker {...})` generation
+            [x] PropertiesLiteral inline embedding vs. PropertiesExpression vtable id embedding
+        [x] fully qualified resolution of expression symbols, e.g. `Transform2d`
+            [-] Alternatively: don't support arbitrary imports yet:
+                [-] Support referring to `T` for any Property<T> (already parsed + resolvable)
+                [-] Import Transform2d::*, Color::*, and a few others via prelude
+                    -- Note that each prelude import prohibits any other top-level symbols with colliding names; increases DX snafu likelihood via compiler errors
+        [x] expression compilation
+            [x] fully qualified resolution of expression symbols, e.g. `Transform2d`
+                [-] Alternatively: don't support arbitrary imports yet:
+                    [-] Support referring to `T` for any Property<T> (already parsed + resolvable)
+                    [-] Import Transform2d::*, Color::*, and a few others via prelude
+                        -- Note that each prelude import prohibits any other top-level symbols with colliding names; increases DX snafu likelihood via compiler errors
+            [x] expression string => RIL generation
+                [x] Pratt parser "hello world"
+                [x] operator definitions to combine `px`, `%`, and numerics with operators `+*/-%`
+                [x] grouping of units, e.g. `(5 + 10)%` 
+                [x] boolean ops: `==`, `&&`, and `||`
+                [x] parenthetical grouping  `(.*)`
+                [x] Literals for strings, bools, ints, floats
+                [x] Nested object references + injected context
+                    [x] invocations for deriving values from scope
+                    [x] type-matching
+                    [x] Numeric type management, type inference / casting
+                [x] QA
+                    [x] fix: order / index of `vtable.insert` statements
+                        -- ordering is jumbled
+                        -- `3` is passed twice
+                    [x] fix: import prelude types like Color::* so that `rgb()` and friends just work
+                    [x] fix: duplicate invocation of `j` in `rgb(100 %, (100 - (j * 12.5)) %, (j * 12.5) %) `
+                    [x] clean: remove "offset example" comment
+                    [x] fix: tuples return usize(0) instead of Range()...
+                    [x] fix: <<TODO>> for invocation of built-ins (either build built-in or refactor...)
+                    [x] fix: need to fully qualify assc. fn. (helpers), e.g. a helper is currently called as `get_frame_size(` instead of `pax_reexports::...::get_frame_size()` 
+            
+    [x] generate / patch chassis cargo.toml
+    
+    [x] control flow
+        [x] for
+            [x] parse declaration `i`, `(i)`, `(i, elem)`
+            [x] handle range literals 0..10 
+            [x] shuttle data into RepeatInstance via Manifest
+        [x] if
+            [x] parse condition, handle as expression
+        [x] slot
+            [x] parse contents as expression/literal, e.g. `slot(i)` or `slot(0)`
+[x] support inline (in-file) component def. (as alternative to `#[pax_file]` file path)
+[x] e2e `pax run`
+[x] publication to crates.io
+    [x] reserve pax-lang crate on crates.io
+    [x] update relative paths in all cargo.tomls, point to hard-coded published versions
+        - can include both a relative path & version number, a feature of Cargo for this exact use-case
+    [x] publish all crates
+```
+
+
+## Milestone: Alpha Launch
+
+```
+HIGH
+zb [ ] hook up `pax_on` and basic lifecycle events
+    [ ] consider design for async while doing this
+    [ ] also requires hooking up `handler_registry` generation in cartridge
+wj [ ] `Numeric` - "unlocks ability to multiply floats & ints"
+    [ ] Introduce wrapper around literal numerics
+    [ ] Build Into and From across expected primitive types (f64, usize, isize, etc.)
+    [ ] Implement necessary Rust operators (`Mul`, etc.), following "truth table" for conversions
+    [ ] Implement necessary non-Rust-builtin-operator operations, like `pow`, on Numeric directly
+    [ ] Refactor Size (maybe take on Color, etc. along the way) to accept numerics 
+        [ ] Chase this thread through the engine, refactoring to support Numeric where necessary (e.g. inside Size)
+zb [ ] (Crude) error reporting through CLI
+    [x] Parser errors (row, column and spatially local text)
+        [ ] Better ParsingError handling, at least surfacing only the line_col info without the noise
+        [ ] Stretch: explore a quick, friendlier error message PoC with "cascading errors in PEG" approach
+    [x] Chassis compilation error
+        [ ] Primitive source-maps
+        - MVP: pipe / output stderr correctly?
+        - Note: this only occurs during lib dev or when encountering a compiler bug in the wild
+                Due to the above, this may not be a blocker on alpha launch
+wj [ ] "code-behind file" as alternative to in-Rust macro
+[x] turn off codesigning for dev harness
+[ ] docs pass
+    [ ] clean up codebase; reduce warnings
+    [ ] README pass & updates
+    [ ] update concepts, appendix articles
+    [ ] Consider writing guides:
+        [ ] Walk through building one or more examples (e.g. show reusable components, expressions, loops, lifecycle event handlers)
+        [ ] Pipeline of compiling a project
+        [ ] Writing a primitive
+wj [ ] support `pax build` for distributable binaries (alternative to `pax run`)
+    [ ] at least web + production build; consider the codesigning question separately
+[ ] interactive demos for docs, website 
+[ ] site
+    [ ] branding
+    [ ] content
+        [ ] audience, outline, etc.
+    [ ] demos
+[ ] windows & linux dev envs
+    [ ] web target only
+    [ ] ensure e2e support & ergonomics
+[ ] usability - high priority
+    [x] figure out spurious stroke / outlining on macOS (clear Piet context?)
+   zb [ ] solve pax-std feature-flagging / "roundup export" / raw coproduct memory access problem
+        [ ] either `pax_primitive_exports` at crate root for external crates — or raw memory access into coproduct
+   zb [ ] Patch in RIL generation for control flow — `Stacker` should work flawlessly, incl. `Slot` and `Repeat`
+    [x] Figure out how to fork process properly in macOS without requiring debug mode
+    [x] Fix native bindings / wasm compile issue (extricate pax-compiler)
+    [x] pax-compiler "cache" — sometimes changes aren't propagated to `.pax/chassis/MacOS` —
+        this is because the file copying logic for `include_dir` aborts when files already exist
+        a solution: manually walk `include_dir` fs and write each file, instead of 
+        using their provided one-shot method 
+    [x] Any easy wins for compile times?
+        [x] See if we can decouple pax-macro from pax-compiler — currently userland projects that rely on pax-macro thus rely on pax-compiler, which in turn has many dependencies and takes a long time to compile.
+        [x] pre-npm-install for web builds?
+        [x] package.json and Cargo.toml dependency cleaning; austerity measures 
+   zb [ ] Refactor Color to accept percentage channel values; refactor Translate/etc. to support
+        [ ] Also design ideal re: constant access -- maybe
+            Color::Rgb(r,g,b) should be a literal enum after all? (instead of fn call)
+            This enables Color::Red() & other "constants" to live under the same symbol, `Color`
+   wj [ ] Introduce x= and y= values, separately from `Transform` (probably a last-applied Translate, in practice)
+        [ ] consider revisiting transform API — keep current functionality, but also add translate=, rotate=, scale=
+            -- this gracefully handles the use-case where complex or nested transforms are required (just use `rotate=120` instead of `transform={Transform2D::rotate(120)}`)
+    [ ] profiling, CPU sanity-optimization (likely: impl. dep graph / dirty-tracking / caching for expressions)
+   zb [ ] Production harness
+        [ ] macos
+            [ ] allow config of apple id / signing cert
+                alt: can probably punt this, until concrete needs arise
+        [ ] web
+            [ ] decide if necessary; maybe same as dev harness for now
+   zb [ ] Warning cleanup
+
+
+MED
+[ ] round out functionality
+    [ ] Text APIs (and fix macOS regression)
+    [x] Path primitive
+        [x] API design
+    [x] Ellipse primitive
+[ ] polish up defaults & expected behavior (e.g. width of a Rect when unspecified)
+
+
+```
+
+## Milestone: usability & functionality++
+
+```
+
+[ ] Cargo cache bug (when changing the contents of @pax/pax-cartridge (template),
+        `cargo clean` is sometimes needed to update the `include_dir` cache.)
+        Is there a better solution than requiring `cargo clean` on lib-dev machines?
+[ ] New units: `rad` and/or `deg` for rotation
+[ ] @settings blocks
+[ ] Runtime error handling
+    [ ] chart out surface area
+        [ ] divide by zero?  what else?
+        [ ] vector access
+    [ ] ideally: patch into source maps
+[ ] consts
+    -- decorate with `#[pax_const]`; copy tokens? or refer to orig?  consider component/namespace reqs
+    -- consider also how to "coordinate between macros" 
+[ ] Support async
+    [ ] `Property` => channels 'smart object'; disposable `mut self` => lifecycle methods (support async lifecycle event handlers)
+    [ ] Pencil out error handling (userland)
+    [ ] update runtime to dispatch event handlers asynchronously, creating and passing "disposable self"s as needed
+[ ] Dependency tracking & dirty-watching
+    [ ] support "helpers", composable functions, which also serve the need of temporaries/`let`s
+    [ ] dependency DAG + lazy evaluation, a la Excel
+        [ ] cache last known values
+        [ ] consider keeping a cache of `state tuple => output value`
+    [ ] address use-case of `Property<Vec<T>>`, inserting/changing an element without setting the whole
+        entity.  Might want to offer a `get_mut` API (keep an eye on async / ownership concerns)
+        -- In fact, probably address this on the heels of a Property -> channel refactor, as the implications for this
+        intersection are significant  
+        -- Solution for now: 1. store Vec<T> inside Property<Vec<T>> — .get_mut() the Vec, mutate, then set() the updated value -- treat the entire property as dirty when this `set` occurs
+[ ] usable error messages
+    [ ] macro-time errors:
+        [ ] write to stderr? or other pipe/file/channel readable by `pax-compiler`
+    [ ] parsetime errors:
+        [ ] pax syntax errors -- error handling with Pest (add "overflow" final rule to grammar at necessary junctures, e.g. `foo = bar | baz | error` — then handle `error` matches at parse-time)
+        [ ] track line/column numbers; figure out how to report back to Rust/editor language server (if possible)
+    [ ] compile-time errors:
+        [ ] handle ad-hoc 
+    [-] runtime errors: probably no special handling needed
+[ ] `with` + event bindings
+    [ ] vtable + wrapper functions for event dispatch; play nicely with HandlerRegistry; add `Scope` or most relevant thing to args list in HandlerRegistry
+    [ ] update `handler_registry` closure codegen in cartridge — call methods with correct signature based on specified `with` 
+    [ ] grammar+parser support
+    [ ] single variables, with option parens (e.g. `with (i)` or `with i`, or `with (i,j,k)`)
+    [ ] multiple variables in tuple `(i,j,k)`
+[ ] Scrolling
+    [ ] Create `Scroller` primitive -- =refer to `Text` primitive for closest reference: pax-std-primitives
+        [ ] Register `Scroller` in `pax-std` and surface for use in `pax-example`
+    [ ] native scrolling container, passes scroll events / position to engine
+        - refer to how `click` events are handled from chassis-macos through the runtime
+    [ ] bounds for scrolling container passed to chassis by engine; chassis instantiates a scrolling container
+    [ ] attach native content as children of the native scroll container, so that native content scrolls natively with no need for Pax runtime intervention
+        - if this introduces "jello" sync problems, instead try updating native elements positions through the vanilla CRUD operations — refer to how `Text` content is updated in `chassis-macos` or `chassis-web`
+    [ ] Update `HandlerRegistry` to account for scroll event handlers; support `@scroll=self.some_handler` registration
+```
+
+## Milestone: form controls
+```
+[ ] `Text` upgrades:
+    [ ] alignment horizontal within bounding box
+    [ ] alignment vertical within bounding box
+    [ ] auto-sizing?  (makes for super-easy alignment; requires letting OS render one frame, possibly off-screen, then applying that calculation.  Requires `interrupt` from chassis after size is measured.
+[ ] Rich text display (Possibly support markdown as authoring format)
+[ ] Dropdown list
+[ ] Slider
+[ ] Toggle buttons (iOS "on/off" style)
+[ ] Button + content (arbitrary rendering content?  or just text to start?)
+[ ] File controls
+    [ ] Upload/open control?
+    [ ] save/download control?
+[ ] Text input boxes
+    [ ] single-line
+    [ ] multi-line?
+    [ ] rich text?
+    [ ] Numeric + stepper?
+[ ] Databinding: event-based changes + two-way binding
+```
+
+## Milestone: iOS & Linux
+```
+[ ] Refactor ABI/FFI layer - Do before adding new targets, so that porting work & waste are reduced
+    [ ] flexbuffers -> flatbuffers, with schema
+    [ ] Port `pax-message/../lib.rs` to a Flexbuffer schema + codegenned Rust
+    [ ] Update macOS messaging layers to support
+    [ ] (Profile overhead of JSON serializing+parsing for Web; decide whether additional footprint cost is worth embedding a flatbuffer reader) 
+[ ] Linux/GTK dev-harness & chassis 
+    [ ] support `NativeMessage`s for all primitives and `std`
+    [ ] dev-harness
+[ ] ios app dev-harness & chassis
+    [ ] support `NativeMessage`s for all primitives and `std`
+    [ ] extract shared logic with macOS dev harness
+    [ ] support ios simulator / physical device
+    [ ] CLI hookups (--target)
+[ ] Touch support
+    [ ] tap / swipe support
+    [ ] `jab` event, for "click or tap"
+```
+
+
+## Milestone: drawing++
+```
+[ ] Image primitive
+    [ ] Bitmap support: .png, .jpg, maybe .svg, serialize as base64 and include encoding so that chassis can make sense of it
+    [ ] API: how to support assets? check out `include_bytes!`
+[ ] Gradient fills: shapes, text
+[ ] Support interpolating Colors; see: `impl Interpolatable for Color {` ... 
+[ ] Opacity (likely built-in property alongside `transform`, `size` -- it accumulates down render tree)
+[ ] Palette built-in: perhaps `@palette { optional_nesting: {  } }
+[ ] Path primitive + APIs for animations
+[ ] Mask primitive (a Clipping primitive that allows a `Path` definition for bounds, instead of a rectangle)
+[ ] Ellipse
+[ ] macOS chassis improvements:
+    [ ] Revisit loop timer?  (keep timestamps, target exact FPS, able to know when frames are dropped)
+ 
+```
+
+
+
+## Milestone: capabilities++
+```
+[ ] support stand-alone .pax files (no rust file); .html use-case
+[ ] asset management -- enables fonts and images
+    [ ] decide on approach: bundle into binary or work with chassis/dev-harness for bundling
+    [ ] support async/http assets, relative paths + configurable prefix path, absolute paths, http/https
+[ ] Text++
+    [ ] custom fonts: embedded or webfonts
+    [ ] basic text + paragraph API
+        [ ] font family, face, weight, decoration
+        [ ] "rich text" or "annotated text" to support mixed content
+        [ ] paragraph: left-align/right-align/justify
+        [ ] (rely on `Transform` for vertical centering)
+[ ] Raster images
+    [ ] Sizing / clipping API (e.g. cover, or anchor + stretch/maintain/fill/target-width/target-height/etc.)
+```
+
+
+
+## Milestone: embedded UI components
+(instead of full-window Electron/Expo-like wrappers)
+
+```
+[ ] Runtime sharing -- allow cartridges to share/sideload a runtime instead of duplicating, e.g. for 100 individual component/cartridges in a codebase
+[ ] Component SDK
+    [ ] per-platform userland API (`mount`)
+    [ ] `component-harness` alternative to `dev-harness` for embedding
+    [ ] Wire up: properties/settings, placeholders,
+    
+```
+
+## Milestone: timelines
+
+```
+[ ] Hook up PropertyTimeline
+    [ ] refactor easing curve packaging, probably into enum
+    [ ] refactor Tweenable, to support arbitrary types (dyn Tweenable) and impl for `fsize`
+    [ ] support Tweenable for f64
+    [ ] support Tweenable for `Transform`
+[ ] ergonomic timeline API design in pax (probably JSON-esque {30: value, 120: other_value} where 30 is frame number
+```
+
+
+## Backlog
+
+```
+[ ] Imperative dirty-tracking API (a la MutationObserver)
+[ ] Temporary lets in PAXEL?
+    [ ] Or: easy composition, "helpers"
+[ ] Support "skinning" the template subgrammar:
+    [ ] KDL
+    [ ] YAML
+    [ ] JSON
+[ ] "Media queries"
+    [ ] built-ins for platforms (`@macos, @web`)
+    [ ] `if` for dynamic application of properties, also responsive/screen-size concerns
+[ ] Pax Browser
+    - simple desktop app, mostly a dev harness, but also
+      supports 
+[ ] Revisit embedded literal strings across codebase for error messages, to reduce binary footprint (enum? codes?)
+[ ] Reinvestigate Any as an alternative to Coproduct generation
+    [ ] would dramatically simplify compiler, code-gen process
+    [ ] would make build process less brittle
+    [ ] roughly: `dyn RenderNode` -> `Box<Any>`, downcast blocks instead of `match ... unreachable!()` blocks
+        [ ] ensure compatibility with `Rc`!  Circa Q4'21, Any could not be downcast to Rc (e.g. `RenderNodePtr`)
+        [ ] de-globalize InstantiationArgs, e.g. `slot_index` and `source_expression`
+        [ ] remove PropertiesCoproduct entirely (and probably repeat the process for TypesCoproduct)
+        [ ] possibly remove two-stage compiler process
+        [ ] sanity check that we can downcast from a given `Any` both to: 1. `dyn RenderNode` (to call methods), and 2. `WhateverProperties` (to access properties)
+        [ ] sanity check that `Any + 'static` will work with needs of `dyn RenderNode` and individual properties
+        [ ] check out downcast_rs crate as way to ease?
+        [ ] ensure that `'static` constraints can be met!! e.g. with dynamically instantiated nodes in `Repeat`
+[ ] Designtime
+    [ ] codegen DefinitionToInstance traverser
+        [ ] codegen in `#[pax]`: From<SettingsLiteralBlockDefinition>
+            [ ] manual
+            [ ] macro
+    [ ] instantiator/traverser logic (codegen or library-coded)
+    [ ] duplex websocket connection + handlers
+        [ ] Write ORM (and maybe caching) methods for `Definitions`
+        [ ] Attach CRUD API endpoints to `Definition` ORM methods via `designtime` server
+    [ ] figure out recompilation loop or hot-reloading of Properties and Expressions
+        [ ] incl. state transfer
+[ ] Margin & padding?
+    [ ] Decide whether to support, e.g. is there a simpler alternative w/ existing pieces?
+    [ ] Decide whether to support ONE or BOTH
+[ ] Component-level defaults ("default masks") for properties (think: design system) -- e.g. "if not specified, all Rectangle > Stroke is _this value_"
+[ ] Frames: overflow scrolling
+[ ] chassis:
+    [ ] iOS
+    [ ] Windows    
+    [ ] Android
+    [ ] Linux (GTK?)
+[ ] Gradients
+    [ ] Multiple (stacked, polymorphic) fills
+    [ ] Gradient strokes?
+[ ] Production compilation
+    [ ] Generation of RIL, feature-gating `designtime`
+[ ] Packaging & imports
+    [ ] Ensure that 3rd party components can be loaded via vanilla import mechanism
+[ ] JavaScript runtime
+    [ ] First-class TypeScript support
+    [ ] API design
+        [ ] code-behind & decorator syntax
+    [ ] Bindings to `runtime` API, plus IPC mechanism for triggering
+[ ] Language server, syntax highlighting, IDE errors (VSCode, JetBrains)
+[ ] Transform.shear
+[ ] 3D renderers
+[ ] Audio/video components
+    [ ] "headless" components?
+```
+
+```
+Creative development environment
+for makers of
+graphical user interfaces
+```
+
+
+
+<img src="pax-compiler/pax-compiler-sequence-diagram.png" />
+<img src="pax-dependency-graph.png" />

--- a/lab-journal-zb.md
+++ b/lab-journal-zb.md
@@ -1,749 +1,4 @@
-# TODO
-
-
-## Milestone: proof of concept engine
-
-```
-[x] Rendering 
-[x] Components 
-[x] Logging
-[x] Stroke, color, fill
-[x] Sizing
-    [x] Browser resize support
-    [x] None-sizing
-    [x] Transform.align
-    [x] Transform.anchor
-[x] Expression engine
-    [x] variables, declaration & storage
-    [x] node IDs
-    [x] summonables
-    [x] built-in vars like frame count
-    [x] MVP rust closures + manifest of deps
-[x] Stackers (née Stacks)
-    [x] Decide `primitive` vs. userland `components`
-    `components`
-    [x] Internal template mechanism for components
-    [x] Make `root` into a component definition
-    [x] Control-flow `slot` (`slot`) for inputs/children
-    [x] Ensure path forward to userland `slots`
-    [x] Clipping & Frames
-    [x] Control-flow `repeat` for cells & dividers inside template
-    [x] Gutter
-[x] Split out userland code
-    [x] Add a third project to workspace, the sample project
-    [x] (Further work to be done via compiler task)
-[x] Timelines, transitions
-[x] Refactors
-    [x] Bundle Transform into "sugary transform," incl. anchor & align; consider a separate transform_matrix property
-    [x] Is there a way to better-DRY the shared logic across render-nodes?
-e.g. check out the `get_size` methods for Frame and Stacker
-    [x] Maybe related to above:  can we DRY the default properties for a render node?
-Perhaps a macro is the answer?
-    Same with `scale`
-    [x] Can we do something better than `(Box<......>, Box<.......>)` for `Size`?
-    [x] Rename various properties, e.g. bounding_dimens => bounds
-    [x] Take a pass on references/ownership in render_render_tree — perhaps &Affine should transfer ownership instead, for example
-    [x] Better ergonomics for `wrap_render_node_ptr_into_list`
-    [x] Evaluate whether to refactor the `unsafe` + PolymorphicType/PolymorphicData approach in expressions + scope data storage
-```
-
-## Milestone: Stacker
-
-```
-[x] decide on API design, expected GUI experience
-    - Direction (horiz/vert)
-    - Gutter
-    - Cell widths
-[x] expose a Stacker element for consumption by engine
-[x] accept children, just like primitives e.g. `Group`
-[x] author an internal template, incl. `slot`ing children and `repeating` inputs
-    <Frame repeat=self.children transform=get_transform(i)>
-        <Slot index=i>
-    </Frame>
-    - need to be able to define/call methods on containing class (a la VB)
-    - need to figure out polymorphism, Vec<T> (?) for repeat
-    - need to figure out slot — special kind of rendernode?
-[x] Frame
-    [x] Clipping
-[x] Slot
-[x] Repeat
-    [x] "flattening yield" to support <Stacker><Repeat n=5><Rect>...
-    [x] scopes:
-        [x] `i`, `datum`
-        [x] braced templating {} ? or otherwise figure out `eval`
-            - Code-gen?  piece together strings into a file and run rustc on it?
-            * Can achieve this with Expressions for now
-        [x] calling "class methods" from templates, e.g. <Repeat n=5><Rect color="get_color(i)"
-            * Can achieve with expressions
-[x] Scopes & DI
-    [x] Figure out dissonance between:  1. string based keys, 2. struct `Properties`
-        and figure out how this plays out into the property DI mechanism.  Along the way,
-        figure out how to inject complex objects (ideally with a path forward to a JS runtime.)
-            - Option A:  write a macro that decorates expression definitions (or _is_ the exp. def.) and (if possible)
-                         generates the necessary code to match param names to elsewhere-registered dependency streams (Angular-style)
-            - Option A0: don't write the macro (above, A) yet, but write the expanded version of it by hand, incl. string deps (present-day approach)
-                         ^ to achieve "DI," does this require a hand-rolled "monomorphization" of each expression invocation?
-                         Or does a string dependency list suffice?  If the latter, we must solve a way to pass a data-type <D> through PolymorphicValue
-                         Probably the answer is the _former_ — write the DI-binding logic manually alongside a string dep list (roughly how the macro unrolling will work)
-    [x] Support getting self (or Scope) for access to Repeat Data
-        - use-case: translate each element within a `repeat` by `i * k`
-    [x] Quick pass on other relevant data to get from Scopes
-[x] Layout
-    [x] Primary logic + repeat via expression
-    [x] Parameterize:
-        - Gutter
-        - (come back later for overrides; ensure design supports visual UX)
-```
-
-## Milestone: expressive RIL, hand-written
-
-_RIL means Rust Intermediate Language, which is the
-"object code" — i.e. compiler backend target — for Pax.  As the name suggests, RIL is valid Rust
-(specifically, a subset of Rust.)  Pax relies on
-`rustc` (via `cargo`) to convert RIL "object code" to machine code._
-
-```
-[x] Compile base cartridge
-    [x] Refactor PropertiesCoproduct to its own module
-    [x] Sanity check "patch" ability for "blanks" (Properties, Expressions)
-    [x] Demo app chassis running example project (`./serve.sh`)
-        [x] Add stub macro for `pax`, derives
-[x] baseline primitive(s) for hello world
-    [x] import/package management
-    [x] RIL -> PAX compatibility, port primitives
-        [x] Repeat, path from @foreach
-[x] hand-write RIL first!
-    [x] Handle control-flow with codegen
-        [x] support with manual RIL, port old primitives
-            [x] @for
-                [x] syntax
-                [x] with/out enumeration (`i`)
-                [x] figure out scoping, e.g. addition of symbols to namespace, collision management
-                [x] RepeatItem: manage scope, properties
-            [x] @if
-            [x] slot
-            [x] frame
-    [x] rendering hello world
-    [x] proof of concept (RIL) for expressions
-    [x] handle expressable + nestable, e.g. Stroke (should be able to set root as Expression, or any individual sub-properties)
-    [x] proof of concept (RIL) for timelines
-        [x] running on assumption that the problem is isomorphic to the Expression vtable problem
-    [x] proof of concept (RIL) for actions
-        [x] pax::log
-        [x] `Tick` support (wired up)
-        [x] pencil in `Click`, but don't worry about raycasting yet (or do naive raycasting?? easy to PoC!)
-        [x] sanity-check Repeat
-    [x] port Repeat, etc. to latest RIL
-[x] API cleanup pass
-    [x] make consistent Size, Percent, Anchor, Align
-    [x] finish-line @if
-    [x] support in-.rs-file pax, as alternative choice vs. code-behind file
-```
-
-## Milestone: imported .pax
-
-```
-[x] Spend some cycles ideating demo deliverables/storyboard
-[x] Port Stacker to be a pure component
-    [x] figure out importing mechanism for core and/or other std primitives
-        [x] Group, Slot (e.g. from Core)
-        [x] Frame (e.g. from std — though if easier could just move to Core)
-    [x] port stacker logic; design expression/method approach
-        [-] pure expressions + helpers?
-        [x] on_will_render + manual dirty checking?
-            [x] decision: no dirty checking at all for right now; expose imperative dirty-check API only when implementing dirty checking for Expressions
-    [x] hook in existing layout calc logic
-[x] Import and use Stacker in Root example
-    [x] update example .pax as needed along the way
-    [x] "expand the proof" of generated code & make it work manually
-```
-
-
-## Milestone: clickable square
-
-```
-[x] Action API
-    [x] state management (.get/.set/etc.)
-    [-] hooks into dirty-update system, to support expression dirty-watching
-    [x] Instantiation, reference management, enum ID + addressing for method definitions &
-        invocations
-    [x] tween/dynamic timeline API
-[x] revisit chassis-web implementation
-    [x] rust/JS divide
-        [x] Sandwich TS and rust (as current,) or
-        [x] handle all cartridge work from rust, incl. generation of public API
-[x] Event capture and transmission
-    [x] Map inputs through chassis, native events (mouse, touch)
-        [x] PoC with Web
-        [x] PoC with macOS
-    [x] tick event e2e
-    [x] Message queue in runtime
-    [x] Ray-casting? probably
-    [x] Message bubbling/capture or similar solution
-[x] Expressions
-    [x] Write ExpressionTable harness, incl. mechanisms for:
-        [x] vtable storage & lookup
-        [x] Return value passing & caching
-    [-] Sketch out design for parallelized expression computation (e.g. in WebWorkers)
-    [-] Patch ExpressionTable into cartridge à la PropertyCoproduct
-```
-
-
-## Milestone: Eureka
-
-```
-[x] resolve the `Any` question
-    [x] defer until later; reassess if it becomes clear a lot of backtracking is emerging 
-[x] parser
-    [x] grammar definition, PEG
-    [x] parse grammar into manifest
-[x] grammar/parser updates:
-    [x] `@for`
-    [x] ranges: literal and symbolic
-    [x] `@template` block, vs. top-level
-[x] native rendering ++
-    [x] message design/arch
-    [x] runtime de/serialization
-        [x] Data across FFI
-            [x] explore raw C structs (decided: brittle)
-            [x] Logging, strings, message-passing
-            [x] CRUD operations and methods: PoC with `Text`
-            [x] flexbuffers instead of fat c structs
-                - Might want to revisit one day for fixed schema, might reduce Swift boilerplate?
-    [x] ids
-        [x] handle monotonic, instance-unique IDs
-            - expose method in engine to generate new id
-            - initial use-case: instance IDs for associating engine <> native Text instances
-    [x] text support
-        [x] handle_did_mount and handle_will_unmount
-        [x] trigger mount/unmount lifecycle events in engine, `Conditional`, `Repeat`
-        [x] hook up Text primitive + API
-            [x] macOS
-            [x] web -- reattach with updated messaging model
-            [x] basic API pass: content, color, font, textSize
-        [x] handle dirty-checking for `Patch` event population
-    [x] native clipping support
-        [x] rectilinear-affine frames
-        [x] support macOS
-        [x] support Web
-    [x] click support
-        [x] simple 2D ray-casting
-            [x] Handle clipped content? and scrolled content? (i.e. check within accumulated clip bounds as well as object bounds)
-        [x] inbound event arg-wrapping and dispatch
-            [x] macos
-            [x] web
-        [x] sketch out bubbling/canceling, hierarchy needs
-[x] dev env ++
-    [x] support for different example projects
-    [x] native macOS chassis + dev-harness
-        [x] pax-chassis-macos (written in rust). responsible for:
-            [x] accepting a CGContext pointer and rendering to it via Piet
-            [x] managing user input channel, e.g. click/touch
-            [x] managing native rendering channel, e.g. form controls, text
-        [x] mac app dev-harness (written in swift). responsible for:
-            [x] granting a piece of real estate (full window of simple mac app) to rendering with a CGContext.
-            [x] passing CGContext to pax-chassis-coregraphics
-            [x] handling resize
-            [x] handling basic user input (e.g. click)
-        [x] Debugging via LLDB
-            [x] support debugging as necessary with macos dev-harness
-            [x] IDE configs for each of: userland cartridge; core; std
-[x] compiler + codegen
-    [-] codegen Cargo.toml + solution for patching
-    Note: decided to require manual Cargo setup for launch (solved by `generate` use-case)
-        [x] manual
-        [-] automated + file generation
-        [-] Note use-case: pax-std also needs the same feature flags + deps.  Would be nice to automate!
-    [x] .pax folder
-        [x] manual .pax folder 'proof'
-        [x] codegen + templating logic
-    [x] generate `pub mod pax_reexports` via `pax_app` -- tricky because full parse is required to
-        know how to build this tree.  Either: do a full parse during macro eval (possible! pending confirmation that parse_to_manifest can be called at macro-expansion time) or
-        do some codegen/patching on the userland project (icky)
-        (Tentative decision: refactor macro-time parse logic; probably do a full parse; return necessary dep strings along with pascal_identifiers)
-        Escape hatch if the above doesn't work: use include_str!() along with a file that contains
-        [x] Refactor parsing logic -- maybe start clean?
-            [x] De-risk: verify ability to call macro-generated code at compile-time (parse_to_manifest)
-            [x] Parse all of, recursively:
-                [x] Template
-                [x] Properties:
-                    [x] Property key
-                    [x] Property type, full module (import) path
-                        [x] This will be tricky... either
-                            [-] static analysis on the whole source file, looking for a `use ... KEYWORD` statement and infer paths
-                            [-] dynamic analysis -- some kind of rustc API.....?
-                            [x] dynamic analysis: `parse_to_manifest`-style `get_module_path`, called by parser
-                                [x] parser returns fully qualified types in manifest by dynamically calling `get_module_path` on each discovered type during parsing
-                                [x] refactor: punch `parser` features through all necessary Cargo.tomls — `impl PropertyManifestable` manually for `Size` and `Size2D`
-                                [-] refactor: instead of `scoped_resolvable_types`, might need to `impl PropertyManifestable` for concrete nested generic types, e.g.
-                                    instead of Vec::get_property_manifest and Rc::get_property_manifest, Vec<Rc<StackerCell>>::get_property_manifest
-                                    -- this addresses compiler error `cannot infer type T for Rc<T>` (non-viable approach)
-                                        [x] Alternatively: hard-code a list of prelude types; treat as blacklist for re-exporting
-                                            -- note that this adds additional complexity/weakness around "global identifier" constraints, i.e. that as currently implemented, there can be no userland `**::**::Rc` or `**::**::Vec`  
-                            [-] Require fully qualified types inside Property<...>, like `Property<crate::SomeType>` or `Property<pax::api::Color>`  
-                            [-] Make Property types `Pathable` or similar, which exposes a method `get_module_path()` that invoked `module_path!()` internally
-                                Then -- `pax` macro can invoke `get_module_path()` just like `parse_to_manifest`
-                                (Evaluated at compiletime) `Color::_get_module_path()`
-                                    ^ wrong -- this would be evaluated at `parser bin`-time
-                                Which returns `pax_runtime_api::Color`
-                                Which gets codegenned into `pub mod pax_reexports`
-                                Checksum: does this resolve at the right time
-                                MAYBE we still need two phases:  one that parses template and property types, which allows codegen of `get_module_path` and `parse_to_manifest`
-                                                                 and another that runs the parser bin
-        [x] Codegen`.pax/reexports.partial.rs`
-            [x] Basic logic
-            [x] Filter prelude
-            [x] fix bug: using `ctx` for property_manifests (maybe only a bug in primitives)
-            [x] Hook up primitives + types
-                -- possibly recycle logic that checks for `Property<...>`
-            [x] fix bug: prelude types not showing up in PropertyManifests
-                -- perhaps each propertymanifest should have:
-                    -- fully qualified atomic types
-                        -- for `pub mod pax_reexports`
-                        -- for recursive calls to `get_property_manifest`
-                        -- for TypesCoproduct generation
-                        -- for cartridge codegen (imports)
-                    -- In each of the above, it should be reasonable to handle prelude vs. imported types separately
-                    -- Also: should this be called something else, like `dependencies` or `imports`? Instead of `PropertyManifests`.
-                    -- What about `properties`?  For design tooling, will definitely be necessary.  Is it worth shimming `dependencies` into 
-                       -- maybe `get_property_manifest` should just be `get_property_dependencies` ??
-        [-] include_str!() `.pax/reexports.partial.rs` _at compile-time_ in macro logic
-            -- the goal is for this types re-export to be present at the root of the *userland project* by the time
-            the chassis is attached / compiled
-            [-] might need to "create if doesn't exist," or otherwise guard the lifecycle of the include_str! per best practice
-                -- a likely-viable approach: feature-gate two complementary `pax_app` macros, across binary values `is parser`
-                   parser mode passes an empty string; prod mode assumes presence of .pax/reexports.partial.rs and hard-code-includes it
-            [x] solution: write another macro, gated behind `not(feature="parser")`, which gets
-                passed `env!("CARGO_MANIFEST_DIR")`
-    [x] parser bin logic finish-line
-        [x] macro
-    [X] untangle dependencies between core, runtime entities (e.g. Transform, RenderTreeContext, RenderNodePtrList), and cartridge
-    [X] work as needed in Engine to accept external cartridge (previously where Component was patched into Engine)
-    [x] update .pest and manifest-populating logic to latest language spec
-    [x] support incremental compilation — not all #[pax] expansions (namely, side-effects) are expected to happen each compilation
-        [-] NOTE: provisionally, this whole group is solved as not necessary, in light of the "parser binary" feature-flagged approach
-        [x] science: determine how macros behave, caching of expansion, incremental compilation
-        [x] allow macros to report their registrants and the appropriate module path + file path via IPC
-        [x] sweep for files that have been removed from fs; update fsdb
-        [x] determine
-        [x] persist fsdb to disk, probably .pax/fsdb, probably binpack
-        [x] enable manual full rebuild, e.g. via `pax compile --full | --force | etc.` (should be doable via rustc with something like INCREMENTAL=0, refer to rust incremental compilation docs)
-    [x] architecture
-        [x] compiler seq. diagram 
-        [x] dependency diagram
-    [x] two-stage compilation process
-        [x] thread/process/IPC chassis
-        [x] parser cargo feature
-        [x] bin-running harness to execute parser (see https://stackoverflow.com/questions/62180215/renaming-main-rs-and-using-with-cargo)
-        [-] TCP message passing (using stdio for now)
-            [x] de/serialization for manifest
-                [x] maybe normalize SelectorLiteralBlockDefinitions, if Serde can't elegantly de/serialize it
-                [x] or de-normalize TemplateNodeDefinition!
-            [-] coordination of TCP client/server from compiler main thread
-        [x] parse and load .pax files
-            [x] load file via macro
-            [x] generate the parser bin logic via macro
-                [x] manual
-            [x] port minimal set of std entities (Rectangle, Group) to support manifest-gen 
-            [x] traverse manifest of Component defs: parse .pax files, store in mem
-            [x] (start with templates only)
-    [x] thread for wrapping `cargo build`
-    [x] sketch out .pax folder design
-    [-] graceful shutdown for threaded chassis (at least: ctrl+c and error handling)
-        [x] Alternatively: back out of async, given stdio for passing data from parser 
-    [x] generate & embed reexports
-        [x] parse properties into manifest
-        [x] bundle pax_reexports into nested mods
-        [x] load reexports.partial.rs into userland project
-    [x] introduce `pax-cli`, import compiler to be a dep
-        [-] `pax demo`?
-        [-] `pax create` 
-    [x] generate properties coproduct
-        [x] retrieve userland crate name (e.g. `pax-example`) and identifier (e.g. `pax_example`) 
-            [-] alternatively, hard-code a single dependency, something like "host", which always points to "../.." (relative to ".pax/properties-coproduct")
-                -- don't think the above will work; cargo needs a symbol that maps to the target Cargo.toml
-        [x] patch / generate Cargo.toml
-            [x] include `pax-example = {path="../../"}`
-                -- where `pax-example` is the userland crate name
-        [x] PropertiesCoproduct
-            -- coproduct of ComponentName
-            [x] run through Tera template, iterating over dependencies
-        [x] TypesCoproduct
-            -- coproduct of all types from PropertyDefinitions 
-            [x] if necessary, supporting type parsing & inference work for TypesCoproduct
-            [x] run through Tera template
-    [x] generate cartridge definition
-        [x] prelude / hard-coded template
-        [x] imports via `pax_example::pax_reexports::*`
-            -- or, fully resolve every import when using
-        [x] component factories
-            [x] `compute_properties_fn` generation
-            [x] `instantiate_root_component` generation, based on `pax_root` declaration
-            [x] `properties: PropertiesCoproduct::Stacker(Stacker {...})` generation
-            [x] PropertiesLiteral inline embedding vs. PropertiesExpression vtable id embedding
-        [x] fully qualified resolution of expression symbols, e.g. `Transform2d`
-            [-] Alternatively: don't support arbitrary imports yet:
-                [-] Support referring to `T` for any Property<T> (already parsed + resolvable)
-                [-] Import Transform2d::*, Color::*, and a few others via prelude
-                    -- Note that each prelude import prohibits any other top-level symbols with colliding names; increases DX snafu likelihood via compiler errors
-        [x] expression compilation
-            [x] fully qualified resolution of expression symbols, e.g. `Transform2d`
-                [-] Alternatively: don't support arbitrary imports yet:
-                    [-] Support referring to `T` for any Property<T> (already parsed + resolvable)
-                    [-] Import Transform2d::*, Color::*, and a few others via prelude
-                        -- Note that each prelude import prohibits any other top-level symbols with colliding names; increases DX snafu likelihood via compiler errors
-            [x] expression string => RIL generation
-                [x] Pratt parser "hello world"
-                [x] operator definitions to combine `px`, `%`, and numerics with operators `+*/-%`
-                [x] grouping of units, e.g. `(5 + 10)%` 
-                [x] boolean ops: `==`, `&&`, and `||`
-                [x] parenthetical grouping  `(.*)`
-                [x] Literals for strings, bools, ints, floats
-                [x] Nested object references + injected context
-                    [x] invocations for deriving values from scope
-                    [x] type-matching
-                    [x] Numeric type management, type inference / casting
-                [x] QA
-                    [x] fix: order / index of `vtable.insert` statements
-                        -- ordering is jumbled
-                        -- `3` is passed twice
-                    [x] fix: import prelude types like Color::* so that `rgb()` and friends just work
-                    [x] fix: duplicate invocation of `j` in `rgb(100 %, (100 - (j * 12.5)) %, (j * 12.5) %) `
-                    [x] clean: remove "offset example" comment
-                    [x] fix: tuples return usize(0) instead of Range()...
-                    [x] fix: <<TODO>> for invocation of built-ins (either build built-in or refactor...)
-                    [x] fix: need to fully qualify assc. fn. (helpers), e.g. a helper is currently called as `get_frame_size(` instead of `pax_reexports::...::get_frame_size()` 
-            
-    [x] generate / patch chassis cargo.toml
-    
-    [x] control flow
-        [x] for
-            [x] parse declaration `i`, `(i)`, `(i, elem)`
-            [x] handle range literals 0..10 
-            [x] shuttle data into RepeatInstance via Manifest
-        [x] if
-            [x] parse condition, handle as expression
-        [x] slot
-            [x] parse contents as expression/literal, e.g. `slot(i)` or `slot(0)`
-[x] support inline (in-file) component def. (as alternative to `#[pax_file]` file path)
-[x] e2e `pax run`
-[x] publication to crates.io
-    [x] reserve pax-lang crate on crates.io
-    [x] update relative paths in all cargo.tomls, point to hard-coded published versions
-        - can include both a relative path & version number, a feature of Cargo for this exact use-case
-    [x] publish all crates
-```
-
-
-## Milestone: Alpha Launch
-
-```
-[ ] Bugs & usability
-    [ ] Cargo cache bug (when changing the contents of @pax/pax-cartridge (template),
-        `cargo clean` is sometimes needed to update the `include_dir` cache.)
-        Is there a better solution than requiring `cargo clean` on lib-dev machines?
-    [ ] pax-compiler "cache" — sometimes changes aren't propagated to `.pax/chassis/MacOS` —
-        this is because the file copying logic for `include_dir` aborts when files already exist
-        a solution: manually walk `include_dir` fs and write each file, instead of 
-        using their provided one-shot method
-    [ ] Warning cleanup pass
-[ ] (Crude) error reporting through CLI
-    [x] Parser errors (row, column and spatially local text)
-        [ ] Stretch: explore a quick, friendlier error message PoC with "cascading errors in PEG" approach
-    [ ] Chassis compilation error
-        - MVP: pipe / output stderr correctly?
-        - Note: this only occurs during lib dev or when encountering a compiler bug in the wild
-                Due to the above, this may not be a blocker on alpha launch
-[ ] "code-behind file" as alternative to in-Rust macro
-[ ] Production harness
-    [ ] macos
-        [ ] allow config of apple id / signing cert
-    [ ] web
-        [ ] decide if necessary; maybe same as dev harness for now
-[x] turn off codesigning for dev harness
-[ ] profiling, CPU optimization (likely: impl. dep graph / dirty-tracking / caching for expressions)
-[ ] windows & linux dev envs
-    [ ] web target only
-    [ ] ensure e2e support & ergonomics
-[ ] hook up `pax_on` and basic lifecycle events
-    [ ] consider design for async while doing this
-    [ ] also requires hooking up `handler_registry` generation in cartridge
-[ ] support `pax build` for distributable binaries (alternative to `pax run`)
-[ ] demo video ++
-[ ] round out functionality
-    [ ] Text APIs (and fix macOS regression)
-    [ ] Path primitive
-        [ ] API design
-    [ ] Ellipse primitive
-[ ] usability
-    [x] figure out spurious stroke / outlining on macOS (clear Piet context?)
-    [ ] solve pax-std feature-flagging / "roundup export" / raw coproduct memory access problem
-        [ ] either `pax_primitive_exports` at crate root for external crates — or raw memory access into coproduct
-    [ ] Support for None-sizing at the level where we assemble the RIL string for size.  Currently, the empty case is 0 pixels, whereas the empty case should be `None` (and thus fill container)
-    [ ] Patch in RIL generation for control flow — `Stacker` should work flawlessly, incl. `Slot` and `Repeat`
-    [x] Figure out how to fork process properly in macOS without requiring debug mode
-    [x] Fix native bindings / wasm compile issue (extricate pax-compiler) 
-    [ ] Any easy wins for compile times?
-        [x] See if we can decouple pax-macro from pax-compiler — currently userland projects that rely on pax-macro thus rely on pax-compiler, which in turn has many dependencies and takes a long time to compile.
-        [ ] pre-npm-install for web builds?
-        [ ] package.json and Cargo.toml dependency cleaning; austerity measures 
-    [ ] Refactor Color to accept percentage channel values; refactor Translate/etc. to support
-        [ ] Also design ideal re: constant access -- maybe
-            Color::Rgb(r,g,b) should be a literal enum after all? (instead of fn call)
-            This enables Color::Red() & other "constants" to live under the same symbol, `Color`
-    [ ] Consider introducing x= and y= values, separately from `Transform` (probably a last-applied Translate, in practice)
-        [ ] consider revisiting transform API — keep current functionality, but also add translate=, rotate=, scale=
-            -- this gracefully handles the use-case where complex or nested transforms are required (just use `rotate=120` instead of `transform={Transform2D::rotate(120)}`)
-[ ] site
-    [ ] branding
-    [ ] content
-    [ ] demos
-[ ] docs pass
-    [ ] clean up codebase; reduce warnings
-    [ ] README pass & updates
-    [ ] update concepts, appendix articles
-    [ ] Consider writing guides:
-        [ ] Walk through building one or more examples (e.g. show reusable components, expressions, loops, lifecycle event handlers)
-        [ ] Pipeline of compiling a project
-        [ ] Writing a primitive
-```
-
-## Milestone: usability & functionality++
-
-```
-[ ] New units: `rad` and/or `deg` for rotation
-[ ] @settings blocks
-[ ] consts
-    -- decorate with `#[pax_const]`; copy tokens? or refer to orig?  consider component/namespace reqs
-    -- consider also how to "coordinate between macros" 
-[ ] Support async
-    [ ] `Property` => channels 'smart object'; disposable `mut self` => lifecycle methods (support async lifecycle event handlers)
-    [ ] Pencil out error handling (userland)
-    [ ] update runtime to dispatch event handlers asynchronously, creating and passing "disposable self"s as needed
-[ ] Dependency tracking & dirty-watching
-    [ ] support "helpers", composable functions, which also serve the need of temporaries/`let`s
-    [ ] dependency DAG + lazy evaluation, a la Excel
-        [ ] cache last known values
-        [ ] consider keeping a cache of `state tuple => output value`
-    [ ] address use-case of `Property<Vec<T>>`, inserting/changing an element without setting the whole
-        entity.  Might want to offer a `get_mut` API (keep an eye on async / ownership concerns)
-        -- In fact, probably address this on the heels of a Property -> channel refactor, as the implications for this
-        intersection are significant  
-        -- Solution for now: 1. store Vec<T> inside Property<Vec<T>> — .get_mut() the Vec, mutate, then set() the updated value -- treat the entire property as dirty when this `set` occurs
-[ ] usable error messages
-    [ ] macro-time errors:
-        [ ] write to stderr? or other pipe/file/channel readable by `pax-compiler`
-    [ ] parsetime errors:
-        [ ] pax syntax errors -- error handling with Pest (add "overflow" final rule to grammar at necessary junctures, e.g. `foo = bar | baz | error` — then handle `error` matches at parse-time)
-        [ ] track line/column numbers; figure out how to report back to Rust/editor language server (if possible)
-    [ ] compile-time errors:
-        [ ] handle ad-hoc 
-    [-] runtime errors: probably no special handling needed
-[ ] `with` + event bindings
-    [ ] vtable + wrapper functions for event dispatch; play nicely with HandlerRegistry; add `Scope` or most relevant thing to args list in HandlerRegistry
-    [ ] update `handler_registry` closure codegen in cartridge — call methods with correct signature based on specified `with` 
-    [ ] grammar+parser support
-    [ ] single variables, with option parens (e.g. `with (i)` or `with i`, or `with (i,j,k)`)
-    [ ] multiple variables in tuple `(i,j,k)`
-[ ] Scrolling
-    [ ] Create `Scroller` primitive -- refer to `Text` primitive for closest reference: pax-std-primitives
-        [ ] Register `Scroller` in `pax-std` and surface for use in `pax-example`
-    [ ] native scrolling container, passes scroll events / position to engine
-        - refer to how `click` events are handled from chassis-macos through the runtime
-    [ ] bounds for scrolling container passed to chassis by engine; chassis instantiates a scrolling container
-    [ ] attach native content as children of the native scroll container, so that native content scrolls natively with no need for Pax runtime intervention
-        - if this introduces "jello" sync problems, instead try updating native elements positions through the vanilla CRUD operations — refer to how `Text` content is updated in `chassis-macos` or `chassis-web`
-    [ ] Update `HandlerRegistry` to account for scroll event handlers; support `@scroll=self.some_handler` registration
-```
-
-## Milestone: form controls
-```
-[ ] `Text` upgrades:
-    [ ] alignment horizontal within bounding box
-    [ ] alignment vertical within bounding box
-    [ ] auto-sizing?  (makes for super-easy alignment; requires letting OS render one frame, possibly off-screen, then applying that calculation.  Requires `interrupt` from chassis after size is measured.
-[ ] Rich text display (Possibly support markdown as authoring format)
-[ ] Dropdown list
-[ ] Slider
-[ ] Toggle buttons (iOS "on/off" style)
-[ ] Button + content (arbitrary rendering content?  or just text to start?)
-[ ] File controls
-    [ ] Upload/open control?
-    [ ] save/download control?
-[ ] Text input boxes
-    [ ] single-line
-    [ ] multi-line?
-    [ ] rich text?
-    [ ] Numeric + stepper?
-[ ] Databinding: event-based changes + two-way binding
-```
-
-## Milestone: iOS & Linux
-```
-[ ] Refactor ABI/FFI layer - Do before adding new targets, so that porting work & waste are reduced
-    [ ] flexbuffers -> flatbuffers, with schema
-    [ ] Port `pax-message/../lib.rs` to a Flexbuffer schema + codegenned Rust
-    [ ] Update macOS messaging layers to support
-    [ ] (Profile overhead of JSON serializing+parsing for Web; decide whether additional footprint cost is worth embedding a flatbuffer reader) 
-[ ] Linux/GTK dev-harness & chassis 
-    [ ] support `NativeMessage`s for all primitives and `std`
-    [ ] dev-harness
-[ ] ios app dev-harness & chassis
-    [ ] support `NativeMessage`s for all primitives and `std`
-    [ ] extract shared logic with macOS dev harness
-    [ ] support ios simulator / physical device
-    [ ] CLI hookups (--target)
-[ ] Touch support
-    [ ] tap / swipe support
-    [ ] `jab` event, for "click or tap"
-```
-
-
-## Milestone: drawing++
-```
-[ ] Image primitive
-    [ ] Bitmap support: .png, .jpg, maybe .svg, serialize as base64 and include encoding so that chassis can make sense of it
-    [ ] API: how to support assets? check out `include_bytes!`
-[ ] Gradient fills: shapes, text
-[ ] Support interpolating Colors; see: `impl Interpolatable for Color {` ... 
-[ ] Opacity (likely built-in property alongside `transform`, `size` -- it accumulates down render tree)
-[ ] Palette built-in: perhaps `@palette { optional_nesting: {  } }
-[ ] Path primitive + APIs for animations
-[ ] Mask primitive (a Clipping primitive that allows a `Path` definition for bounds, instead of a rectangle)
-[ ] Ellipse
-[ ] macOS chassis improvements:
-    [ ] Revisit loop timer?  (keep timestamps, target exact FPS, able to know when frames are dropped)
- 
-```
-
-
-
-## Milestone: capabilities++
-```
-[ ] support stand-alone .pax files (no rust file); .html use-case
-[ ] asset management -- enables fonts and images
-    [ ] decide on approach: bundle into binary or work with chassis/dev-harness for bundling
-    [ ] support async/http assets, relative paths + configurable prefix path, absolute paths, http/https
-[ ] Text++
-    [ ] custom fonts: embedded or webfonts
-    [ ] basic text + paragraph API
-        [ ] font family, face, weight, decoration
-        [ ] "rich text" or "annotated text" to support mixed content
-        [ ] paragraph: left-align/right-align/justify
-        [ ] (rely on `Transform` for vertical centering)
-[ ] Raster images
-    [ ] Sizing / clipping API (e.g. cover, or anchor + stretch/maintain/fill/target-width/target-height/etc.)
-```
-
-
-
-## Milestone: embedded UI components
-(instead of full-window Electron/Expo-like wrappers)
-
-```
-[ ] Runtime sharing -- allow cartridges to share/sideload a runtime instead of duplicating, e.g. for 100 individual component/cartridges in a codebase
-[ ] Component SDK
-    [ ] per-platform userland API (`mount`)
-    [ ] `component-harness` alternative to `dev-harness` for embedding
-    [ ] Wire up: properties/settings, placeholders,
-    
-```
-
-## Milestone: timelines
-
-```
-[ ] Hook up PropertyTimeline
-    [ ] refactor easing curve packaging, probably into enum
-    [ ] refactor Tweenable, to support arbitrary types (dyn Tweenable) and impl for `fsize`
-    [ ] support Tweenable for f64
-    [ ] support Tweenable for `Transform`
-[ ] ergonomic timeline API design in pax (probably JSON-esque {30: value, 120: other_value} where 30 is frame number
-```
-
-
-## Backlog
-
-```
-[ ] Imperative dirty-tracking API (a la MutationObserver)
-[ ] Temporary lets in PAXEL?
-    [ ] Or: easy composition, "helpers"
-[ ] Support "skinning" the template subgrammar:
-    [ ] KDL
-    [ ] YAML
-    [ ] JSON
-[ ] "Media queries"
-    [ ] built-ins for platforms (`@macos, @web`)
-    [ ] `if` for dynamic application of properties, also responsive/screen-size concerns
-[ ] Pax Browser
-    - simple desktop app, mostly a dev harness, but also
-      supports 
-[ ] Revisit embedded literal strings across codebase for error messages, to reduce binary footprint (enum? codes?)
-[ ] Reinvestigate Any as an alternative to Coproduct generation
-    [ ] would dramatically simplify compiler, code-gen process
-    [ ] would make build process less brittle
-    [ ] roughly: `dyn RenderNode` -> `Box<Any>`, downcast blocks instead of `match ... unreachable!()` blocks
-        [ ] ensure compatibility with `Rc`!  Circa Q4'21, Any could not be downcast to Rc (e.g. `RenderNodePtr`)
-        [ ] de-globalize InstantiationArgs, e.g. `slot_index` and `source_expression`
-        [ ] remove PropertiesCoproduct entirely (and probably repeat the process for TypesCoproduct)
-        [ ] possibly remove two-stage compiler process
-        [ ] sanity check that we can downcast from a given `Any` both to: 1. `dyn RenderNode` (to call methods), and 2. `WhateverProperties` (to access properties)
-        [ ] sanity check that `Any + 'static` will work with needs of `dyn RenderNode` and individual properties
-        [ ] check out downcast_rs crate as way to ease?
-        [ ] ensure that `'static` constraints can be met!! e.g. with dynamically instantiated nodes in `Repeat`
-[ ] Designtime
-    [ ] codegen DefinitionToInstance traverser
-        [ ] codegen in `#[pax]`: From<SettingsLiteralBlockDefinition>
-            [ ] manual
-            [ ] macro
-    [ ] instantiator/traverser logic (codegen or library-coded)
-    [ ] duplex websocket connection + handlers
-        [ ] Write ORM (and maybe caching) methods for `Definitions`
-        [ ] Attach CRUD API endpoints to `Definition` ORM methods via `designtime` server
-    [ ] figure out recompilation loop or hot-reloading of Properties and Expressions
-        [ ] incl. state transfer
-[ ] Margin & padding?
-    [ ] Decide whether to support, e.g. is there a simpler alternative w/ existing pieces?
-    [ ] Decide whether to support ONE or BOTH
-[ ] Component-level defaults ("default masks") for properties (think: design system) -- e.g. "if not specified, all Rectangle > Stroke is _this value_"
-[ ] Frames: overflow scrolling
-[ ] chassis:
-    [ ] iOS
-    [ ] Windows    
-    [ ] Android
-    [ ] Linux (GTK?)
-[ ] Gradients
-    [ ] Multiple (stacked, polymorphic) fills
-    [ ] Gradient strokes?
-[ ] Production compilation
-    [ ] Generation of RIL, feature-gating `designtime`
-[ ] Packaging & imports
-    [ ] Ensure that 3rd party components can be loaded via vanilla import mechanism
-[ ] JavaScript runtime
-    [ ] First-class TypeScript support
-    [ ] API design
-        [ ] code-behind & decorator syntax
-    [ ] Bindings to `runtime` API, plus IPC mechanism for triggering
-[ ] Language server, syntax highlighting, IDE errors (VSCode, JetBrains)
-[ ] Transform.shear
-[ ] 3D renderers
-[ ] Audio/video components
-    [ ] "headless" components?
-```
-
-```
-Creative development environment
-for makers of
-graphical user interfaces
-```
-
-
-
-<img src="pax-compiler/pax-compiler-sequence-diagram.png" />
-<img src="pax-dependency-graph.png" />
-
-
-
-## zb lab journal
+# Lab Journal, zb
 
 ### untangling Definitions, Values, and Patches
 2022/01/27
@@ -3480,6 +2735,89 @@ remains to finish-line the feature-gating labor / wiring
      This approach might require using `#[repr(C)]` on the PropertiesCoproduct
      and then manually reaching into memory to pluck out the datum from the disc. union
 
+### Lab journal zb, 2023-02-19
+
+Consider the snippet:
+```
+for i in 0..4 {
+        <Group transform={Transform2D::rotate(i * 0.07)} >
+```
+`i` is a `usize` (or perhaps `isize`, TBD)
+`0.07` is an `f64`.  In the current state of codegen,
+`i` is multiplied by `0.07`, yielding the rustc error:
+```
+81 | ...e::Percent(50.into())),))*Transform2D::rotate(((i *0.07.try_into().unwrap())),))
+   |                                                      -     ^^^^^^^^
+   |                                                      |
+   |                                                      type must be known at this point
+```
+
+Possible approaches:
+
+1. Numeric wrapper
+
+Introduce a new type `Numeric` with `From` and `Into` built for each primitive types across Rust's `{floats, integers}`
+Fill a truth table describing the cross-product of `set of all pax operators` ⨯ `operand 0 from domain {Numeric::Float, Numeric::Integer}` ⨯ `operand 1 from domain {Numeric::Float, Numeric::Integer}`
+e.g., for multiplication:
+
+```
+MULTIPLICATION operator (`x`)
+`Float` `x` `Float` => `Float`
+`Integer` `x` `Float` => `Float`
+`Float` `x` `Integer` => `Float`
+`Integer` `x` `Integer` => `Integer`
+```
+(and so on, for remaining supported operators.  consider the unary operator `-`, also)
+
+Further, implement `Mul<Numeric>`, etc., for each Rust operator that we ever
+generate literally, e.g. incl. `%`
 
 
- 
+## Lab journal, Mar 13 2023
+
+Pursued some improvements to macOS build today.  In particular,
+focused on enabling multi-arch builds, partly to chase down the errors coming 
+from xcodebuild:
+
+```
+Ld /Users/zack/Library/Developer/Xcode/DerivedData/pax-dev-harness-macos-ceupzrmwryakhafqxlfbcvhpgytw/Build/Intermediates.noindex/ArchiveIntermediates/Pax\ macOS/InstallationBuildProductsLocation/Applications/Pax\ macOS.app/Contents/MacOS/Pax\ macOS normal (in target 'Pax macOS' from project 'pax-dev-harness-macos')
+    cd /Users/zack/code/pax/pax-example/.pax/chassis/MacOS/pax-dev-harness-macos
+    /Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/clang -target x86_64-apple-macos12.0 -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX13.1.sdk -L/Users/zack/Library/Developer/Xcode/DerivedData/pax-dev-harness-macos-ceupzrmwryakhafqxlfbcvhpgytw/Build/Intermediates.noindex/ArchiveIntermediates/Pax\ macOS/IntermediateBuildFilesPath/EagerLinkingTBDs -L/Users/zack/Library/Developer/Xcode/DerivedData/pax-dev-harness-macos-ceupzrmwryakhafqxlfbcvhpgytw/Build/Intermediates.noindex/ArchiveIntermediates/Pax\ macOS/BuildProductsPath/Debug -L/Users/zack/code/pax/pax-example/.pax/chassis/MacOS/pax-dev-harness-macos/../target/debug -F/Users/zack/Library/Developer/Xcode/DerivedData/pax-dev-harness-macos-ceupzrmwryakhafqxlfbcvhpgytw/Build/Intermediates.noindex/ArchiveIntermediates/Pax\ macOS/IntermediateBuildFilesPath/EagerLinkingTBDs -F/Users/zack/Library/Developer/Xcode/DerivedData/pax-dev-harness-macos-ceupzrmwryakhafqxlfbcvhpgytw/Build/Intermediates.noindex/ArchiveIntermediates/Pax\ macOS/BuildProductsPath/Debug -filelist /Users/zack/Library/Developer/Xcode/DerivedData/pax-dev-harness-macos-ceupzrmwryakhafqxlfbcvhpgytw/Build/Intermediates.noindex/ArchiveIntermediates/Pax\ macOS/IntermediateBuildFilesPath/pax-dev-harness-macos.build/Debug/Pax\ macOS.build/Objects-normal/x86_64/Pax\ macOS.LinkFileList -Xlinker -rpath -Xlinker @executable_path/../Frameworks -Xlinker -object_path_lto -Xlinker /Users/zack/Library/Developer/Xcode/DerivedData/pax-dev-harness-macos-ceupzrmwryakhafqxlfbcvhpgytw/Build/Intermediates.noindex/ArchiveIntermediates/Pax\ macOS/IntermediateBuildFilesPath/pax-dev-harness-macos.build/Debug/Pax\ macOS.build/Objects-normal/x86_64/Pax\ macOS_lto.o -Xlinker -export_dynamic -Xlinker -no_deduplicate -Xlinker -final_output -Xlinker /Applications/Pax\ macOS.app/Contents/MacOS/Pax\ macOS -fobjc-link-runtime -L/Applications/Xcode.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx -L/usr/lib/swift -Xlinker -add_ast_path -Xlinker /Users/zack/Library/Developer/Xcode/DerivedData/pax-dev-harness-macos-ceupzrmwryakhafqxlfbcvhpgytw/Build/Intermediates.noindex/ArchiveIntermediates/Pax\ macOS/IntermediateBuildFilesPath/pax-dev-harness-macos.build/Debug/Pax\ macOS.build/Objects-normal/x86_64/Pax_macOS.swiftmodule -lpaxchassismacos -lpaxchassismacos -Xlinker -dependency_info -Xlinker /Users/zack/Library/Developer/Xcode/DerivedData/pax-dev-harness-macos-ceupzrmwryakhafqxlfbcvhpgytw/Build/Intermediates.noindex/ArchiveIntermediates/Pax\ macOS/IntermediateBuildFilesPath/pax-dev-harness-macos.build/Debug/Pax\ macOS.build/Objects-normal/x86_64/Pax\ macOS_dependency_info.dat -o /Users/zack/Library/Developer/Xcode/DerivedData/pax-dev-harness-macos-ceupzrmwryakhafqxlfbcvhpgytw/Build/Intermediates.noindex/ArchiveIntermediates/Pax\ macOS/InstallationBuildProductsLocation/Applications/Pax\ macOS.app/Contents/MacOS/Pax\ macOS
+ld: warning: ignoring file /Users/zack/code/pax/pax-example/.pax/chassis/MacOS/target/debug/libpaxchassismacos.dylib, building for macOS-x86_64 but attempting to link with file built for macOS-arm64
+Undefined symbols for architecture x86_64:
+  "_pax_dealloc_message_queue", referenced from:
+      _$s9Pax_macOS0A10CanvasViewC4drawyySo6CGRectVF in PaxView.o
+  "_pax_init", referenced from:
+      _$s9Pax_macOS0A10CanvasViewC4drawyySo6CGRectVF in PaxView.o
+  "_pax_interrupt", referenced from:
+      _$s9Pax_macOS0A4ViewV4bodyQrvgy7SwiftUI11DragGestureV5ValueVcfU0_ySWXEfU_ySPySo15InterruptBufferVGXEfU_ in PaxView.o
+  "_pax_tick", referenced from:
+      _$s9Pax_macOS0A10CanvasViewC4drawyySo6CGRectVF in PaxView.o
+ld: symbol(s) not found for architecture x86_64
+clang: error: linker command failed with exit code 1 (use -v to see invocation)
+
+** ARCHIVE FAILED **
+
+
+The following build commands failed:
+	Ld /Users/zack/Library/Developer/Xcode/DerivedData/pax-dev-harness-macos-ceupzrmwryakhafqxlfbcvhpgytw/Build/Intermediates.noindex/ArchiveIntermediates/Pax\ macOS/InstallationBuildProductsLocation/Applications/Pax\ macOS.app/Contents/MacOS/Pax\ macOS normal (in target 'Pax macOS' from project 'pax-dev-harness-macos')
+(1 failure)
+```
+
+Things I did:
+
+1.) explored path of using conditional LIBRARY_SEARCH_PATHs in the xcode project definition by manually editing file -- see README in cargo-lipo project for a pointer. Ultimately was unable to get xcode to resolve the dylib(s) appropriately when building. Might be surmountable with more config twiddling — note that this required editing the .pbxproj file by hand
+
+2.) explored using cargo lipo to build a "fat binary" including all necessary arch builds information, then using that single embed (presumably, dylib file) for xcode. Problem: I was only able to get a `.a` file out of cargo lipo, rather than a `.dylib` (was able to get two `.dylibs`, across target/x86_64-apple-darwin and target/aarch64-apple-darwin, but didn't verify whether either of them was unexpectedly the "fat lib.". If that single `.a` file is enough, need to figure out how to get xcode project to build around that, which was not an immediately intuitive refactor.
+
+3.) yet another option, unexplored: make mac x86_64 (intel) a completely different chassis or harness pair, vs. the aarch64 chassis / harness-pair.  Might even template or codegen out multiple variants of the macos chassis, swapping just architecture strings in the .pbxproj file.
+
+In any case, when supporting cross-arch builds (building for other flavors of Mac from either Intel or ARM), steps like the following will be needed:
+(previously added these to README while working on this, in hopes of shipping, but
+ended up pulling back and dropping this lab journal entry instead.)
+
+```
+- run `rustup target add aarch64-apple-darwin`
+- run `rustup target add x86_64-apple-darwin`
+- install cargo-lipo with `cargo install cargo-lipo` (needed for cross-architecture builds, `x86_64` and `aarch64`)
+```

--- a/pax-chassis-macos/Cargo.toml
+++ b/pax-chassis-macos/Cargo.toml
@@ -8,14 +8,13 @@ homepage = "https://pax.rs/"
 repository = "https://www.github.com/pax-lang/pax"
 description = "Platform-specific chassis allowing Pax cartridges to be executed as native macOS apps"
 
-
 [build]
 lto = true
 incremental = false
 
 [lib]
 name = "paxchassismacos"
-crate-type = ["cdylib"]
+crate-type = ["staticlib", "cdylib"]
 
 [dependencies]
 piet = "0.6.0"
@@ -27,21 +26,9 @@ pax-runtime-api = {path = "../pax-runtime-api", version="0.0.1"}
 pax-properties-coproduct = {path = "../pax-example/.pax/properties-coproduct", version="0.0.1"}
 lazy_static = "1.4.0"
 mut_static = "5.0.0"
-core-graphics = "0.22.3"
-serde = "1.0"
-flexbuffers = "2.0.0"
-
 #be cautious about core-graphics' version number --
 #ideally this would be locked with `piet` (the specified version should exactly match the version used
 #internally by piet-coregraphics, e.g. 0.6.0 => 0.22.3)
-
-
-#[patch.'file:///Users/zack/code/pax-lang/pax-properties-coproduct']
-#pax-properties-coproduct = {path = "../pax-cartridge/pax-properties-coproduct"}
-#
-#[patch.'file:///Users/zack/code/pax-lang/pax-cartridge']
-#pax-cartridge = {path = "../pax-cartridge/pax-cartridge"}
-
-#[patch.crates-io]
-#pax-properties-coproduct = {path = "../pax-cartridge/pax-properties-coproduct"}
-#pax-cartridge = {path = "../pax-cartridge/pax-cartridge"}
+core-graphics = "0.22.3"
+serde = "1.0"
+flexbuffers = "2.0.0"

--- a/pax-compiler/Cargo.toml
+++ b/pax-compiler/Cargo.toml
@@ -21,7 +21,7 @@ pax-message = {version = "0.0.1", path="../pax-message"}
 pest = "2.4.1"
 pest_derive = "2.4.1"
 itertools = "0.10.5"
-include_dir = {version = "0.7.2", features = ["glob"]}
+include_dir = {version = "0.7.3", features = ["glob"]}
 serde_derive = "1"
 toml_edit = "0.14.4"
 lazy_static = "1.4.0"

--- a/pax-compiler/src/expressions.rs
+++ b/pax-compiler/src/expressions.rs
@@ -86,7 +86,7 @@ fn recurse_compile_expressions<'a>(mut ctx: ExpressionCompilationContext<'a>) ->
                             id,
                             pascalized_return_type,
                             invocations,
-                            output_statement: output_statement,
+                            output_statement,
                             input_statement: identifier.clone(),
                         });
                     }
@@ -103,17 +103,24 @@ fn recurse_compile_expressions<'a>(mut ctx: ExpressionCompilationContext<'a>) ->
 
                     let active_node_component = (&ctx.all_components.get(&ctx.active_node_def.component_id)).expect(&format!("No known component with identifier {}.  Try importing or defining a component named {}", &ctx.active_node_def.component_id, &ctx.active_node_def.component_id));
 
-                    let pascalized_return_type = if attr.0 == "transform" {
-                        //FUTURE: DRY & robustify
-                        "Transform2D".to_string()
-                    } else if attr.0 == "size" {
-                        //FUTURE: DRY & robustify
-                        "Size2D".to_string()
+
+                    let builtin_types = HashMap::from([
+                        ("transform","Transform2D".to_string()),
+                        ("size","Size2D".to_string()),
+                        ("width","Size".to_string()),
+                        ("height","Size".to_string()),
+                        // ("x","Size".to_string()),
+                        // ("y","Size".to_string()),
+
+                    ]);
+
+                    let pascalized_return_type = if let Some(type_string) = builtin_types.get(&*attr.0) {
+                        type_string.to_string()
                     } else {
                         (active_node_component.property_definitions.iter().find(|property_def| {
                             property_def.name == attr.0
                         }).expect(
-                            &format!("Property `{}` not found on component `{}`", &attr.0, &ctx.component_def.pascal_identifier)
+                            &format!("Property `{}` not found on component `{}`", &attr.0, &active_node_component.pascal_identifier)
                         ).property_type_info.pascalized_fully_qualified_type).clone()
                     };
 

--- a/pax-compiler/src/parsing.rs
+++ b/pax-compiler/src/parsing.rs
@@ -185,8 +185,8 @@ fn recurse_pratt_parse_to_string<'a>(expression: Pairs<Rule>, pratt_parser: &Pra
                         format!("Numeric::from({})", value)
                     }
                     _ => {
-                        /* {literal_enum_value | literal_tuple_access |  string | literal_tuple } */
-                        literal_kind.as_str().to_string() + ".into()"
+                        /* {literal_enum_value | literal_tuple_access | string | literal_tuple } */
+                        literal_kind.as_str().to_string() + ".try_into().unwrap()"
                     }
                 }
             },
@@ -313,6 +313,7 @@ fn parse_template_from_component_definition_string(ctx: &mut TemplateNodeParseCo
             pascal_identifier: "<UNREACHABLE>".to_string()
         }
     );
+
 
 }
 

--- a/pax-compiler/templates/cartridge-lib.tera
+++ b/pax-compiler/templates/cartridge-lib.tera
@@ -30,11 +30,19 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     vtable.insert({{ expression_spec.id }}, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         {% for invocation in expression_spec.invocations %}
             let {{ invocation.escaped_identifier }} = {
-                let properties = (*ec.stack_frame).borrow().nth_descendant({{ invocation.stack_offset }});
+                let properties = (*ec.stack_frame).borrow().nth_descendant({{ invocation.stack_offset }})
+                    .unwrap()
+                    .borrow()
+                    .deref()
+                    .get_properties();
                 let properties = &*(*properties).borrow();
 
                 if let PropertiesCoproduct::{{ invocation.properties_type }}(p) = properties {
+                    {% if invocation.properties_type == "usize" %}
+                    *p
+                    {% else %}
                     *p.{{invocation.identifier}}.get()
+                    {% endif %}
                 } else {
                     unreachable!("{{ expression_spec.id }}")
                 }

--- a/pax-compiler/templates/properties-coproduct-lib.tera
+++ b/pax-compiler/templates/properties-coproduct-lib.tera
@@ -5,6 +5,7 @@ pub enum PropertiesCoproduct {
     None,
     RepeatList(Vec<Rc<RefCell<PropertiesCoproduct>>>),
     RepeatItem(Rc<PropertiesCoproduct>, usize),
+    usize(usize), //used by Repeat with numeric ranges, like `for i in 0..5`
     {% for properties_coproduct_tuple in properties_coproduct_tuples %}
     {{properties_coproduct_tuple.0}}({{properties_coproduct_tuple.1}}),
     {% endfor %}

--- a/pax-example/.pax/properties-coproduct/src/lib.rs
+++ b/pax-example/.pax/properties-coproduct/src/lib.rs
@@ -5,10 +5,9 @@ pub enum PropertiesCoproduct {
     None,
     RepeatList(Vec<Rc<RefCell<PropertiesCoproduct>>>),
     RepeatItem(Rc<PropertiesCoproduct>, usize),
+    usize(usize), //used by Repeat with numeric ranges, like `for i in 0..5`
     
     Ellipse(pax_example::pax_reexports::pax_std::primitives::Ellipse),
-    
-    Group(pax_example::pax_reexports::pax_std::primitives::Group),
     
     HelloRGB(pax_example::pax_reexports::HelloRGB),
     

--- a/pax-example/.pax/reexports.partial.rs
+++ b/pax-example/.pax/reexports.partial.rs
@@ -3,7 +3,6 @@ pub mod pax_reexports {
 	pub mod pax_std {
 		pub mod primitives {
 			pub use pax_std::primitives::Ellipse;
-			pub use pax_std::primitives::Group;
 			pub use pax_std::primitives::Path;
 			pub use pax_std::primitives::Rectangle;
 			pub use pax_std::primitives::Text;

--- a/pax-example/src/lib.rs
+++ b/pax-example/src/lib.rs
@@ -3,14 +3,21 @@ use pax::*;
 use pax_std::components::Stacker;
 use pax_std::primitives::{Ellipse, Frame, Group, Path, Rectangle, Text};
 
-#[pax_app(
-    <Group transform={Transform2D::align(50%, 50%) * Transform2D::anchor(50%, 50%) * Transform2D::rotate(0.07)} >
-        <Text text="Hello world" />
-        <Path segments={Path::curve_to(Path::line_to(Path::start(), (0.0,0.0), (500.0, 500.0)), (800.0,500.0) , (0.0,0.0) , (700.0,300.0) )}  />
-        <Ellipse fill={Color::rgb(0,0.5,0)} width=33.33% height=100% />
-        <Rectangle fill={Color::rgb(1,0.5,0)} width=33.33% height=100% />
 
-    </Group>
+#[pax_app(
+    // for i in 0..5 {
+    //    <Group transform={Transform2D::align(50%, 50%) * Transform2D::anchor(50%, 50%) * Transform2D::rotate(i * 0.07)} >
+            <Text text="Hello world" />
+            <Path />
+            <Ellipse fill={Color::rgb(0.5,0,1)} width=33.33% height=100% transform={
+                Transform2D::align(50%, 0%) * Transform2D::anchor(50%, 0%)
+            } />
+            <Rectangle fill={Color::rgb(1,0.8,0.1)} width=33.33% height=100% transform={
+                Transform2D::align(100%, 0%) * Transform2D::anchor(100%, 0%)
+            } />
+            <Rectangle fill={Color::rgb(0.25,0.5,0.5)} width=100% height=100% />
+    //    </Group>
+    // }
 )]
 pub struct HelloRGB {
     pub rects: Property<Vec<usize>>,

--- a/pax-macro/src/parsing.rs
+++ b/pax-macro/src/parsing.rs
@@ -3,7 +3,7 @@
 extern crate pest;
 use pest_derive::Parser;
 use pest::Parser;
-use pest::iterators::{Pair, Pairs};
+use pest::iterators::{Pair};
 
 
 use std::rc::Rc;
@@ -74,7 +74,7 @@ fn recurse_visit_tag_pairs_for_pascal_identifiers(any_tag_pair: Pair<Rule>, pasc
         Rule::statement_control_flow => {
             let matched_tag = any_tag_pair.into_inner().next().unwrap();
 
-            let mut n = 1;
+            let mut n : usize;
             match matched_tag.as_rule() {
                 Rule::statement_if => {
                     n = 2;

--- a/pax-macro/src/templating.rs
+++ b/pax-macro/src/templating.rs
@@ -1,6 +1,7 @@
 use sailfish::TemplateOnce;
 
-use serde_derive::{Serialize, Deserialize};
+use serde_derive::{Serialize};
+#[allow(unused)]
 use serde_json;
 
 use std::collections::HashSet;

--- a/pax-message/src/lib.rs
+++ b/pax-message/src/lib.rs
@@ -3,10 +3,8 @@ extern crate serde;
 
 pub mod reflection;
 
-use std::ffi::CString;
-use std::os::raw::c_char;
-
 //FUTURE: feature-flag, only for Web builds
+#[allow(unused_imports)]
 use wasm_bindgen::prelude::*;
 
 use serde::{Serialize};

--- a/pax-properties-coproduct/src/lib.rs
+++ b/pax-properties-coproduct/src/lib.rs
@@ -6,6 +6,8 @@ pub enum PropertiesCoproduct {
     None,
     RepeatList(Vec<Rc<RefCell<PropertiesCoproduct>>>),
     RepeatItem(Rc<PropertiesCoproduct>, usize),
+    usize(usize),//used by Repeat + numeric ranges, e.g. `for i in 0..5`
+
     //generated
 }
 

--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -37,8 +37,6 @@ pub trait PropertyInstance<T: Default + Clone> {
     /// Used by engine to gain access to this property's transition queue
     fn _get_transition_manager(&mut self) -> Option<&mut TransitionManager<T>>;
 
-    // fn get_eased_value(&self) -> Option<T>
-
     /// Immediately start transitioning from current value to the provided `new_value`,
     /// clearing the transition queue before doing so
     fn ease_to(&mut self, new_value: T, duration_frames: u64, curve: EasingCurve);
@@ -48,17 +46,11 @@ pub trait PropertyInstance<T: Default + Clone> {
     /// transition will be the final value upon completion of the current transition queue.
     fn ease_to_later(&mut self, new_value: T, duration_frames: u64, curve: EasingCurve);
 
-
-    //to_default: set back to default value
-    //ease_to_default: set back to default value via interpolation
+    //Wishlist:
+    // to_default: set back to default value
+    // ease_to_default: set back to default value via interpolation
 }
 
-
-// impl<T: Debug + Default + Clone + 'static> Debug for Box<dyn PropertyInstance<T>> {
-//     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-//         self.get().fmt(f)
-//     }
-// }
 
 impl<T: Default + Clone + 'static> Default for Box<dyn PropertyInstance<T>> {
     fn default() -> Box<dyn PropertyInstance<T>> {
@@ -78,34 +70,6 @@ pub enum ArgsCoproduct {
 }
 
 pub type Property<T: Interpolatable> = Box<dyn PropertyInstance<T>>;
-//
-// pub struct VecProperty<T: Interpolatable> {
-//     internal_properties: Vec<Property<T>>,
-//     //expose Vec api
-//     //handle internal propertyinstances
-// }
-//
-
-// impl<T: Interpolatable, I: Sized> Index<I> for VecProperty<T> {
-//     type Output = Property<T>;
-//
-//     fn index(&self, index: I) -> &Self::Output {
-//         self.internal_properties.get(index)
-//     }
-// }
-//
-// impl<T: Interpolatable, I: Sized> std::ops::IndexMut<I> for VecProperty<T> {
-//     fn index_mut(&mut self, index: I) -> &mut Property<T> {
-//         &mut self.internal_properties.get_mut(index)
-//     }
-// }
-//
-// impl<T: Interpolatable> VecProperty<T> {
-//     fn push(&mut self, elem: T) {
-//         self.internal_properties.push(Box::new(PropertyLiteral::new(elem)));
-//     }
-// }
-
 
 #[derive(Clone)]
 pub struct ArgsRender {


### PR DESCRIPTION
also: introduce `persistent_extract` to help combat libdev cache stickiness
also: cleaning