### PR TITLE
refactored run and implemented build

### DIFF
--- a/pax-chassis-macos/pax-dev-harness-macos/run-debuggable-mac-app.sh
+++ b/pax-chassis-macos/pax-dev-harness-macos/run-debuggable-mac-app.sh
@@ -3,8 +3,13 @@
 # Expects args:
 # 1: VERBOSE ∈ {"true" | "false"}
 # 2: EXCLUDE_ARCHS ∈ {"arm64" | "x86_64"}
+# 3: SHOULD_ALSO_RUN ∈ {"true" | "false"}
+# 4: OUTPUT_PATH : output directory for build
 VERBOSE=$1
 EXCLUDE_ARCHS=$2
+SHOULD_ALSO_RUN=$3
+OUTPUT_PATH=$4
+
 
 runbuild () {
   xcodebuild archive \
@@ -24,5 +29,13 @@ else
   runbuild > /dev/null 2>&1 >&2
 fi
 
-# Run
-build/PaxDevHarnessMacos.xcarchive/Products/Applications/Pax\ macOS.app/Contents/MacOS/Pax\ macOS
+# Clear old build and move to output directory
+rm -rf $OUTPUT_PATH
+mkdir -p $OUTPUT_PATH
+cp -r "build/PaxDevHarnessMacos.xcarchive/Products/Applications/Pax macOS.app" $OUTPUT_PATH
+cd $OUTPUT_PATH
+
+if [ "$SHOULD_ALSO_RUN" == "true" ]; then
+  # Run
+  Pax\ macOS.app/Contents/MacOS/Pax\ macOS
+fi

--- a/pax-chassis-web/pax-dev-harness-web/run-web.sh
+++ b/pax-chassis-web/pax-dev-harness-web/run-web.sh
@@ -1,5 +1,20 @@
 #!/bin/sh
 
-set -ex
+SHOULD_ALSO_RUN=$1
+OUTPUT_PATH=$2
 
-yarn serve || (yarn && yarn serve)
+# Clear old build and move to output directory
+rm -rf $OUTPUT_PATH
+mkdir -p $OUTPUT_PATH
+cp -r "." $OUTPUT_PATH
+cd $OUTPUT_PATH
+
+# Remove this script in output directory
+rm -- "$0"
+
+if [ "$SHOULD_ALSO_RUN" == "true" ]; then
+  # Run
+  set -ex
+  yarn serve || (yarn && yarn serve)
+fi
+

--- a/pax-compiler/src/lib.rs
+++ b/pax-compiler/src/lib.rs
@@ -910,7 +910,7 @@ fn build_harness_with_chassis(pax_dir: &PathBuf, ctx: &RunContext, harness: &Har
     };
 
     let is_web = if let RunTarget::Web = ctx.target { true } else { false };
-    let target_folder = if is_web { "Web "} else {"MacOS"};
+    let target_folder : &str = ctx.target.borrow().into();
     let path = fs::canonicalize(std::path::Path::new(&ctx.path)).unwrap();
     let output_path = path.join("build").join(target_folder);
     let output_path_val = output_path.to_str().unwrap();
@@ -933,19 +933,20 @@ fn build_harness_with_chassis(pax_dir: &PathBuf, ctx: &RunContext, harness: &Har
             .expect("failed to run harness")
             .wait()
             .expect("failed to run harness");
+    } else {
+        Command::new(script)
+            .current_dir(&harness_path)
+            .arg(verbose_val)
+            .arg(exclude_arch_val)
+            .arg(should_also_run)
+            .arg(output_path_val)
+            .stdout(std::process::Stdio::inherit())
+            .stderr(if ctx.verbose { std::process::Stdio::inherit() } else {std::process::Stdio::piped()})
+            .spawn()
+            .expect("failed to run harness")
+            .wait()
+            .expect("failed to run harness");
     }
-    Command::new(script)
-        .current_dir(&harness_path)
-        .arg(verbose_val)
-        .arg(exclude_arch_val)
-        .arg(should_also_run)
-        .arg(output_path_val)
-        .stdout(std::process::Stdio::inherit())
-        .stderr(if ctx.verbose { std::process::Stdio::inherit() } else {std::process::Stdio::piped()})
-        .spawn()
-        .expect("failed to run harness")
-        .wait()
-        .expect("failed to run harness");
 }
 
 /// Runs `cargo build` (or `wasm-pack build`) with appropriate env in the directory


### PR DESCRIPTION
All builds (with or without running) will be copied to a `build` folder within the specified path. 
If we are running as well then that will be the build that will be executed. 