### PR TITLE
upgraded sdk to 13.3 and lowered minimum deployment to 13.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Use `rustc` 1.65.0 via `rustup`
 ### Environment setup, building for macOS
 
 - Install xcode, command line utils
-- SDK Version `macosx13.3`
+- SDK Version `macosx13.3`, Xcode version `>=14.3`
 - Current Minimum Deployment `13.0`
 
 ### Running Development Environment

--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Use `rustc` 1.65.0 via `rustup`
 ### Environment setup, building for macOS
 
 - Install xcode, command line utils
+- SDK Version `macosx13.3`
+- Current Minimum Deployment `13.0`
 
 ### Running Development Environment
 

--- a/pax-chassis-macos/pax-dev-harness-macos/pax-dev-harness-macos.xcodeproj/project.pbxproj
+++ b/pax-chassis-macos/pax-dev-harness-macos/pax-dev-harness-macos.xcodeproj/project.pbxproj
@@ -363,11 +363,12 @@
 					"@executable_path/../Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../../target/debug";
-				MACOSX_DEPLOYMENT_TARGET = 13.1;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.pax-lang.pax-dev-harness-macos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx13.3;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/Paxchassismacos-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;
@@ -396,11 +397,12 @@
 					"@executable_path/../Frameworks",
 				);
 				LIBRARY_SEARCH_PATHS = "$(PROJECT_DIR)/../../target/debug";
-				MACOSX_DEPLOYMENT_TARGET = 13.1;
+				MACOSX_DEPLOYMENT_TARGET = 13.0;
 				MARKETING_VERSION = 1.0;
 				PRODUCT_BUNDLE_IDENTIFIER = "org.pax-lang.pax-dev-harness-macos";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				PROVISIONING_PROFILE_SPECIFIER = "";
+				SDKROOT = macosx13.3;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_OBJC_BRIDGING_HEADER = "$(PROJECT_DIR)/Paxchassismacos-Bridging-Header.h";
 				SWIFT_VERSION = 5.0;

--- a/pax-chassis-macos/pax-dev-harness-macos/run-debuggable-mac-app.sh
+++ b/pax-chassis-macos/pax-dev-harness-macos/run-debuggable-mac-app.sh
@@ -16,7 +16,7 @@ runbuild () {
   -configuration Debug \
   -scheme "Pax macOS" \
   -archivePath build/PaxDevHarnessMacos.xcarchive \
-  -sdk macosx13.1 \
+  -sdk macosx13.3 \
   SKIP_INSTALL=NO SUPPORTS_MACCATALYST=YES ONLY_ACTIVE_ARCH=YES EXCLUDED_ARCHS="$EXCLUDE_ARCHS"
 }
 


### PR DESCRIPTION
Fixes slash through Pax app icon on Mac