### PR TITLE
unsafe_unwrap! macro for enum unwrapping

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ target/
 
 pax-chassis-macos/pax-dev-harness-macos/build
 pax-example/.pax/chassis/
+pax-example/build/
 
 **/*.rs.bk
 Cargo.lock

--- a/.idea/pax.iml
+++ b/.idea/pax.iml
@@ -17,6 +17,7 @@
       <sourceFolder url="file://$MODULE_DIR$/pax-example/examples" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/pax-example/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/pax-std/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/pax-core/tests" isTestSource="true" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
       <excludeFolder url="file://$MODULE_DIR$/pax-example/.pax/chassis/MacOS/target" />
       <excludeFolder url="file://$MODULE_DIR$/pax-example/target" />

--- a/pax-compiler/templates/properties-coproduct-lib.tera
+++ b/pax-compiler/templates/properties-coproduct-lib.tera
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+#[repr(u32)]
 pub enum PropertiesCoproduct {
     None,
     RepeatList(Vec<Rc<RefCell<PropertiesCoproduct>>>),
@@ -12,6 +13,7 @@ pub enum PropertiesCoproduct {
 }
 
 //used namely for return types of expressions — may have other purposes
+#[repr(u32)]
 pub enum TypesCoproduct {
     {% for types_coproduct_tuple in types_coproduct_tuples %}
     {{types_coproduct_tuple.0}}({{types_coproduct_tuple.1}}),

--- a/pax-core/src/declarative_macros.rs
+++ b/pax-core/src/declarative_macros.rs
@@ -1,0 +1,27 @@
+/// Extracts the target value from an enum using raw memory access.
+///
+/// Parameters:
+/// - `$source_enum`: The enum instance to extract the target value from.
+/// - `$enum_type`: The type of the enum.
+/// - `$target_type`: The type of the target value to extract.
+#[macro_export]
+macro_rules! unsafe_unwrap {
+    ($source_enum:expr, $enum_type:ty, $target_type:ty) => {{
+        fn unwrap_impl<T, U>(source_enum: T) -> U {
+            let size_of_enum = std::mem::size_of::<T>();
+            let size_of_target = std::mem::size_of::<U>();
+            let align_of_enum = std::mem::align_of::<T>();
+
+            assert!(size_of_target < size_of_enum, "The size_of target_type must be less than the size_of enum_type.");
+
+            let boxed_enum = Box::new(source_enum);
+            let target = unsafe {
+                let enum_ptr = Box::into_raw(boxed_enum);
+                let ptr_to_text = ((enum_ptr as *const u8).add(align_of_enum) as *const U);
+                ptr_to_text.read()
+            };
+            target
+        }
+        unwrap_impl::<$enum_type, $target_type>($source_enum)
+    }};
+}

--- a/pax-core/src/lib.rs
+++ b/pax-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod repeat;
 pub mod slot;
 pub mod runtime;
 pub mod conditional;
+pub mod declarative_macros;
 // pub mod timelines;
 // pub mod designtime;
 

--- a/pax-core/tests/declarative_macro_tests.rs
+++ b/pax-core/tests/declarative_macro_tests.rs
@@ -1,0 +1,24 @@
+use pax_core::unsafe_unwrap;
+
+#[derive(Debug, PartialEq)]
+#[repr(u32)]
+enum Fruit {
+    Apple(String),
+    Banana(String),
+}
+
+#[test]
+fn test_unwrap_apple() {
+    let fruit = Fruit::Apple("green".to_string());
+    let expected_color = "green".to_string();
+    let unwrapped_color: String =
+        unsafe_unwrap!(fruit, Fruit, String);
+    assert_eq!(unwrapped_color, expected_color);
+}
+
+#[test]
+#[should_panic(expected = "The size_of target_type must be less than the size_of enum_type.")]
+fn test_unwrap_invalid_size() {
+    let fruit = Fruit::Apple("red".to_string());
+    let _unwrapped_fruit: Fruit = unsafe_unwrap!(fruit, Fruit, Fruit);
+}

--- a/pax-example/.pax/cartridge/src/lib.rs
+++ b/pax-example/.pax/cartridge/src/lib.rs
@@ -18,25 +18,11 @@ use pax_example::pax_reexports::f64;
 
 use pax_example::pax_reexports::pax_std::types::Color;
 
-use pax_example::pax_reexports::pax_std::types::Font;
-
-use pax_example::pax_reexports::pax_std::types::PathSegment;
-
 use pax_example::pax_reexports::pax_std::types::Stroke;
-
-use pax_example::pax_reexports::std::string::String;
-
-use pax_example::pax_reexports::std::vec::Vec;
 
 use pax_example::pax_reexports::HelloRGB;
 
 use pax_example::pax_reexports::pax_std::primitives::Ellipse;
-
-use pax_example::pax_reexports::pax_std::primitives::Path;
-
-use pax_example::pax_reexports::pax_std::primitives::Rectangle;
-
-use pax_example::pax_reexports::pax_std::primitives::Text;
 
 
 //pull in entire const token stream here e.g. `const JABBERWOCKY : &str = r#"’Twas brillig, and the slithy toves `...
@@ -80,36 +66,6 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
         #[allow(unused_parens)]
         TypesCoproduct::Transform2D(
             ((Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)*Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),))*Transform2D::rotate(((rotation).into()),))
-        )
-    }));
-    
-    //Color::rgb(1,0.8,0.1)
-    vtable.insert(2, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::__pax_stdCOCOtypesCOCOColor(
-            Color::rgb((Numeric::from(1)),(Numeric::from(0.8)),(Numeric::from(0.1)),)
-        )
-    }));
-    
-    //Transform2D::align(100%,0%)*Transform2D::anchor(100%,0%)
-    vtable.insert(3, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::Transform2D(
-            (Transform2D::align((Size::Percent(100.into())),(Size::Percent(0 .into())),)*Transform2D::anchor((Size::Percent(100.into())),(Size::Percent(0 .into())),))
-        )
-    }));
-    
-    //Color::rgb(0.25,0.5,0.5)
-    vtable.insert(4, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::__pax_stdCOCOtypesCOCOColor(
-            Color::rgb((Numeric::from(0.25)),(Numeric::from(0.5)),(Numeric::from(0.5)),)
         )
     }));
     
@@ -166,146 +122,6 @@ pax_std_primitives::ellipse::EllipseInstance::instantiate(
     transform: Rc::new(RefCell::new(PropertyExpression::new(1))),
     size: Some(Rc::new(RefCell::new(
         [Box::new(PropertyLiteral::new(Size::Percent(33.33.into()))),Box::new(PropertyLiteral::new(Size::Percent(100.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-
-,
-
-pax_std_primitives::rectangle::RectangleInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Rectangle( Rectangle {
-        
-            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyExpression::new(2) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(3))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Percent(33.33.into()))),Box::new(PropertyLiteral::new(Size::Percent(100.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-
-,
-
-pax_std_primitives::text::TextInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Text( Text {
-        
-            text: Box::new( PropertyLiteral::new("Hello world".try_into().unwrap()) ),
-        
-            font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Default::default())),Box::new(PropertyLiteral::new(Default::default()))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-
-,
-
-pax_std_primitives::path::PathInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Path( Path {
-        
-            segments: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Default::default())),Box::new(PropertyLiteral::new(Default::default()))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-
-,
-
-pax_std_primitives::rectangle::RectangleInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Rectangle( Rectangle {
-        
-            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyExpression::new(4) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Percent(100.into()))),Box::new(PropertyLiteral::new(Size::Percent(100.into())))]
     ))),
     children: Some(Rc::new(RefCell::new(vec![
         

--- a/pax-example/.pax/properties-coproduct/src/lib.rs
+++ b/pax-example/.pax/properties-coproduct/src/lib.rs
@@ -1,6 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 
+#[repr(u32)]
 pub enum PropertiesCoproduct {
     None,
     RepeatList(Vec<Rc<RefCell<PropertiesCoproduct>>>),
@@ -11,15 +12,10 @@ pub enum PropertiesCoproduct {
     
     HelloRGB(pax_example::pax_reexports::HelloRGB),
     
-    Path(pax_example::pax_reexports::pax_std::primitives::Path),
-    
-    Rectangle(pax_example::pax_reexports::pax_std::primitives::Rectangle),
-    
-    Text(pax_example::pax_reexports::pax_std::primitives::Text),
-    
 }
 
 //used namely for return types of expressions — may have other purposes
+#[repr(u32)]
 pub enum TypesCoproduct {
     
     Size(pax_runtime_api::Size),
@@ -32,19 +28,13 @@ pub enum TypesCoproduct {
     
     Transform2D(pax_runtime_api::Transform2D),
     
-    VecLABR__pax_stdCOCOtypesCOCOPathSegmentRABR(Vec<pax_example::pax_reexports::pax_std::types::PathSegment>),
-    
     Vec_Rc_PropertiesCoproduct___(std::vec::Vec<std::rc::Rc<PropertiesCoproduct>>),
     
     __f64(pax_example::pax_reexports::f64),
     
     __pax_stdCOCOtypesCOCOColor(pax_example::pax_reexports::pax_std::types::Color),
     
-    __pax_stdCOCOtypesCOCOFont(pax_example::pax_reexports::pax_std::types::Font),
-    
     __pax_stdCOCOtypesCOCOStroke(pax_example::pax_reexports::pax_std::types::Stroke),
-    
-    __stdCOCOstringCOCOString(pax_example::pax_reexports::std::string::String),
     
     bool(bool),
     

--- a/pax-example/.pax/reexports.partial.rs
+++ b/pax-example/.pax/reexports.partial.rs
@@ -4,23 +4,10 @@ pub mod pax_reexports {
 	pub mod pax_std {
 		pub mod primitives {
 			pub use pax_std::primitives::Ellipse;
-			pub use pax_std::primitives::Path;
-			pub use pax_std::primitives::Rectangle;
-			pub use pax_std::primitives::Text;
 		}
 		pub mod types {
 			pub use pax_std::types::Color;
-			pub use pax_std::types::Font;
-			pub use pax_std::types::PathSegment;
 			pub use pax_std::types::Stroke;
-		}
-	}
-	pub mod std {
-		pub mod string {
-			pub use std::string::String;
-		}
-		pub mod vec {
-			pub use std::vec::Vec;
 		}
 	}
 }

--- a/pax-example/src/lib.rs
+++ b/pax-example/src/lib.rs
@@ -4,7 +4,16 @@ use pax_std::components::Stacker;
 use pax_std::primitives::{Ellipse, Frame, Group, Path, Rectangle, Text};
 
 
-#[pax_file("example.pax")]
+#[pax_app(
+    <Ellipse @scroll=self.handle_scroll @click=self.handle_click fill={Color::rgb(0.5,0,1)} width=33.33% height=100% transform={
+        Transform2D::align(50%, 50%) * Transform2D::anchor(50%, 50%) * Transform2D::rotate(rotation)
+    } />
+
+    @events {
+            Click: [self.handle_global_click],
+            Scroll: self.handle_global_scroll,
+    }
+)]
 pub struct HelloRGB {
     pub rotation: Property<f64>,
 }

--- a/pax-std/pax-std-primitives/src/ellipse.rs
+++ b/pax-std/pax-std-primitives/src/ellipse.rs
@@ -3,7 +3,7 @@ use piet::{RenderContext};
 
 use pax_std::primitives::{Ellipse};
 use pax_std::types::ColorVariant;
-use pax_core::{Color, TabCache, RenderNode, RenderNodePtrList, RenderTreeContext, ExpressionContext, InstanceRegistry, HandlerRegistry, InstantiationArgs, RenderNodePtr};
+use pax_core::{Color, TabCache, RenderNode, RenderNodePtrList, RenderTreeContext, ExpressionContext, InstanceRegistry, HandlerRegistry, InstantiationArgs, RenderNodePtr, unsafe_unwrap};
 use pax_core::pax_properties_coproduct::{PropertiesCoproduct, TypesCoproduct};
 use pax_runtime_api::{PropertyInstance, PropertyLiteral, Size, Transform2D, Size2D, ArgsCoproduct};
 
@@ -33,8 +33,7 @@ impl<R: 'static + RenderContext>  RenderNode<R> for EllipseInstance<R> {
     }
 
     fn instantiate(mut args: InstantiationArgs<R>) -> Rc<RefCell<Self>> where Self: Sized {
-        let properties = if let PropertiesCoproduct::Ellipse(p) = args.properties { p } else {unreachable!("Wrong properties type")};
-
+        let properties = unsafe_unwrap!(args.properties, PropertiesCoproduct, Ellipse);
         let mut instance_registry = (*args.instance_registry).borrow_mut();
         let instance_id = instance_registry.mint_id();
         let ret = Rc::new(RefCell::new(EllipseInstance {

--- a/pax-std/pax-std-primitives/src/path.rs
+++ b/pax-std/pax-std-primitives/src/path.rs
@@ -3,7 +3,7 @@ use piet::{RenderContext};
 
 use pax_std::primitives::{Path};
 use pax_std::types::{ColorVariant, CurveSegmentData, LineSegmentData, PathSegment};
-use pax_core::{Color, TabCache, RenderNode, RenderNodePtrList, RenderTreeContext, ExpressionContext, InstanceRegistry, HandlerRegistry, InstantiationArgs, RenderNodePtr};
+use pax_core::{Color, TabCache, RenderNode, RenderNodePtrList, RenderTreeContext, ExpressionContext, InstanceRegistry, HandlerRegistry, InstantiationArgs, RenderNodePtr, unsafe_unwrap};
 use pax_core::pax_properties_coproduct::{PropertiesCoproduct, TypesCoproduct};
 use pax_runtime_api::{PropertyInstance, PropertyLiteral, Size, Transform2D, Size2D, ArgsCoproduct};
 
@@ -32,7 +32,7 @@ impl<R: 'static + RenderContext>  RenderNode<R> for PathInstance<R> {
     }
 
     fn instantiate(mut args: InstantiationArgs<R>) -> Rc<RefCell<Self>> where Self: Sized {
-        let properties = if let PropertiesCoproduct::Path(p) = args.properties { p } else {unreachable!("Wrong properties type")};
+        let properties = unsafe_unwrap!(args.properties, PropertiesCoproduct, Path);
 
         let mut instance_registry = (*args.instance_registry).borrow_mut();
         let instance_id = instance_registry.mint_id();
@@ -80,7 +80,7 @@ impl<R: 'static + RenderContext>  RenderNode<R> for PathInstance<R> {
 
 
         if let Some(segments) = rtc.compute_vtable_value(properties.segments._get_vtable_id()) {
-            let new_value = if let TypesCoproduct::VecLABR__pax_stdCOCOtypesCOCOPathSegmentRABR(v) = segments { v } else { unreachable!() };
+            let new_value = unsafe_unwrap!(segments, TypesCoproduct, Vec<PathSegment>);
             properties.segments.set(new_value);
         }
 

--- a/pax-std/pax-std-primitives/src/rectangle.rs
+++ b/pax-std/pax-std-primitives/src/rectangle.rs
@@ -3,9 +3,9 @@ use piet::{RenderContext};
 
 use pax_std::primitives::{Rectangle};
 use pax_std::types::ColorVariant;
-use pax_core::{Color, TabCache, RenderNode, RenderNodePtrList, RenderTreeContext, ExpressionContext, InstanceRegistry, HandlerRegistry, InstantiationArgs, RenderNodePtr};
+use pax_core::{Color, TabCache, RenderNode, RenderNodePtrList, RenderTreeContext, ExpressionContext, InstanceRegistry, HandlerRegistry, InstantiationArgs, RenderNodePtr, unsafe_unwrap};
 use pax_core::pax_properties_coproduct::{PropertiesCoproduct, TypesCoproduct};
-use pax_runtime_api::{PropertyInstance, PropertyLiteral, Size, Transform2D, Size2D, ArgsCoproduct};
+use pax_runtime_api::{PropertyInstance, PropertyLiteral, Size, Transform2D, Size2D, ArgsCoproduct, Property};
 
 use std::str::FromStr;
 use std::cell::RefCell;
@@ -33,8 +33,7 @@ impl<R: 'static + RenderContext>  RenderNode<R> for RectangleInstance<R> {
     }
 
     fn instantiate(mut args: InstantiationArgs<R>) -> Rc<RefCell<Self>> where Self: Sized {
-        let properties = if let PropertiesCoproduct::Rectangle(p) = args.properties { p } else {unreachable!("Wrong properties type")};
-
+        let properties = unsafe_unwrap!(args.properties, PropertiesCoproduct, Rectangle);
         let mut instance_registry = (*args.instance_registry).borrow_mut();
         let instance_id = instance_registry.mint_id();
         let ret = Rc::new(RefCell::new(RectangleInstance {

--- a/pax-std/pax-std-primitives/src/text.rs
+++ b/pax-std/pax-std-primitives/src/text.rs
@@ -2,11 +2,9 @@ use std::cell::RefCell;
 use std::ffi::CString;
 use std::rc::Rc;
 use std::collections::HashMap;
-
 use piet::{RenderContext};
-
 use pax_std::primitives::{Text};
-use pax_core::{ComputableTransform, TabCache, HandlerRegistry, InstantiationArgs, RenderNode, RenderNodePtr, RenderNodePtrList, RenderTreeContext};
+use pax_core::{ComputableTransform, TabCache, HandlerRegistry, InstantiationArgs, RenderNode, RenderNodePtr, RenderNodePtrList, RenderTreeContext, unsafe_unwrap};
 use pax_core::pax_properties_coproduct::{PropertiesCoproduct, TypesCoproduct};
 use pax_message::{AnyCreatePatch, TextPatch};
 use pax_runtime_api::{PropertyInstance, Transform2D, Size2D, PropertyLiteral};
@@ -33,18 +31,9 @@ impl<R: 'static + RenderContext>  RenderNode<R> for TextInstance<R> {
         self.instance_id
     }
 
-
     fn instantiate(mut args: InstantiationArgs<R>) -> Rc<RefCell<Self>> where Self: Sized {
 
-        // #[cfg(feature="Text")]
-        let properties = if let PropertiesCoproduct::Text(p) = args.properties { p } else { unreachable!("Wrong properties type") };
-         // #[cfg(not(feature="Text"))]
-         // let properties = Text {
-         //     text: Default::default(),
-         //     font: Default::default(),
-         //     fill: Default::default(),
-         // };
-
+        let properties = unsafe_unwrap!(args.properties, PropertiesCoproduct, Text);
 
         let mut instance_registry = (*args.instance_registry).borrow_mut();
         let instance_id = instance_registry.mint_id();
@@ -61,7 +50,7 @@ impl<R: 'static + RenderContext>  RenderNode<R> for TextInstance<R> {
         instance_registry.register(instance_id, Rc::clone(&ret) as RenderNodePtr<R>);
         ret
     }
-    
+
     fn get_rendering_children(&self) -> RenderNodePtrList<R> {
         Rc::new(RefCell::new(vec![]))
     }


### PR DESCRIPTION
Added a new macro for unsafe unwrap and subbed it into primitives. 
Went down the path of adding a discriminant check for the variant until I realized that we need to know the order of the enum which isn't possible since it's created dynamically.