### PR TITLE
match scrollingDeltaY direction to web

### DIFF
--- a/pax-chassis-macos/pax-dev-harness-macos/pax-dev-harness-macos/PaxView.swift
+++ b/pax-chassis-macos/pax-dev-harness-macos/pax-dev-harness-macos/PaxView.swift
@@ -223,7 +223,7 @@ struct PaxView: View {
         
         override func scrollWheel(with event: NSEvent){
             let deltaX = event.scrollingDeltaX
-            let deltaY = event.scrollingDeltaY
+            let deltaY = -event.scrollingDeltaY
             let x = event.locationInWindow.x;
             let y = event.locationInWindow.y;
             let json = String(format: "{\"Scroll\": {\"x\": %f, \"y\": %f, \"delta_x\": %f, \"delta_y\": %f} }", x, y, deltaX, deltaY);


### PR DESCRIPTION
In macOS, when using the scrollingDeltaY property from an NSEvent object, a positive value represents scrolling down (i.e., content moves up), whereas a negative value represents scrolling up (i.e., content moves down). This behavior is consistent regardless of whether natural scrolling is enabled or not.

In web browsers, however, a positive value for the deltaY property of a WheelEvent object represents scrolling up (i.e., content moves down), while a negative value represents scrolling down (i.e., content moves up). This behavior is consistent across different web browsers.

Tauri & Electron use web behavior so defaulting to that.