### PR TITLE
Occlusion for Web

### DIFF
--- a/pax-chassis-macos/src/lib.rs
+++ b/pax-chassis-macos/src/lib.rs
@@ -126,6 +126,7 @@ pub extern "C" fn pax_interrupt(engine_container: *mut PaxEngineContainer, buffe
                 ImageLoadInterruptArgs::Data(_) => {}
             }
         }
+        _ => {}
     }
 
     unsafe {(*engine_container)._engine=  Box::into_raw(engine)};
@@ -143,7 +144,10 @@ pub extern "C" fn pax_tick(engine_container: *mut PaxEngineContainer, cgContext:
     let mut render_context = CoreGraphicsContext::new_y_up(ctx, height as f64, None);
     (*engine).set_viewport_size((width as f64, height as f64));
 
-    let messages = (*engine).tick(&mut render_context);
+    let mut render_contexts = Vec::new();
+    render_contexts.push(render_context);
+
+    let messages = (*engine).tick(&mut render_contexts);
 
     let wrapped_queue = MessageQueue{messages,};
     let mut serializer = flexbuffers::FlexbufferSerializer::new();

--- a/pax-chassis-web/Cargo.toml
+++ b/pax-chassis-web/Cargo.toml
@@ -31,4 +31,4 @@ js-sys = "0.3.63"
 
 [dependencies.web-sys]
 version = "0.3.10"
-features = ["console", "CanvasRenderingContext2d", "Window", "Document", "Element", "HtmlCanvasElement", "Event"]
+features = ["console", "CanvasRenderingContext2d", "Window", "Document", "Element", "HtmlCanvasElement", "Event", "HtmlCollection"]

--- a/pax-chassis-web/pax-dev-harness-web/index.ts
+++ b/pax-chassis-web/pax-dev-harness-web/index.ts
@@ -28,7 +28,7 @@ let layers: { "native": HTMLDivElement[], "canvas": HTMLCanvasElement[] } = { "n
 
 function main(wasmMod: typeof import('./dist/pax_chassis_web')) {
 
-    initializeLayers(100);
+    initializeLayers(1);
     //Initialize chassis & engine
     let chassis = wasmMod.PaxChassisWeb.new();
 

--- a/pax-core/src/component.rs
+++ b/pax-core/src/component.rs
@@ -44,7 +44,7 @@ impl<R: 'static + RenderContext> RenderNode<R> for ComponentInstance<R> {
         }
     }
 
-    fn handle_did_render(&mut self, rtc: &mut RenderTreeContext<R>, _rc: &mut R) {
+    fn handle_did_render(&mut self, rtc: &mut RenderTreeContext<R>, _rcs: &mut Vec<R>) {
         (*rtc.runtime).borrow_mut().pop_stack_frame();
     }
 

--- a/pax-example/.pax/cartridge/src/lib.rs
+++ b/pax-example/.pax/cartridge/src/lib.rs
@@ -66,10 +66,10 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     let mut vtable: HashMap<usize, Box<dyn Fn(ExpressionContext<R>) -> TypesCoproduct>> = HashMap::new();
 
     
-    //current_route == 2 
+    //Transform2D::align(50%,50%)*Transform2D::anchor(50%,50%)*Transform2D::rotate(rotation)
     vtable.insert(0, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
-            let current_route = {
+            let rotation = {
                 let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
                     Rc::clone(&sf)
                 } else {
@@ -78,9 +78,9 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
                 let properties = &*(*properties).borrow();
 
                 
-                    if let PropertiesCoproduct::Example(p) = properties {
+                    if let PropertiesCoproduct::HelloRGB(p) = properties {
                         
-                            Numeric::from(p.current_route.get())
+                            Numeric::from(p.rotation.get())
                         
                     } else {
                         unreachable!("0")
@@ -90,76 +90,38 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
         
 
         #[allow(unused_parens)]
-        TypesCoproduct::bool(
-            (current_route ==Numeric::from(2 ))
+        TypesCoproduct::Transform2D(
+            ((Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())*(Transform2D::rotate((rotation),)).into())
         )
     }));
     
-    //current_route == 1 
+    //Color::rgb(0.4,0.5,0)
     vtable.insert(1, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
-            let current_route = {
-                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
-                    Rc::clone(&sf)
-                } else {
-                    Rc::clone(&ec.stack_frame)
-                }.borrow().deref().get_properties();
-                let properties = &*(*properties).borrow();
-
-                
-                    if let PropertiesCoproduct::Example(p) = properties {
-                        
-                            Numeric::from(p.current_route.get())
-                        
-                    } else {
-                        unreachable!("1")
-                    }
-                
-            };
-        
 
         #[allow(unused_parens)]
-        TypesCoproduct::bool(
-            (current_route ==Numeric::from(1 ))
-        )
-    }));
-    
-    //current_route == 0 
-    vtable.insert(2, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-            let current_route = {
-                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
-                    Rc::clone(&sf)
-                } else {
-                    Rc::clone(&ec.stack_frame)
-                }.borrow().deref().get_properties();
-                let properties = &*(*properties).borrow();
-
-                
-                    if let PropertiesCoproduct::Example(p) = properties {
-                        
-                            Numeric::from(p.current_route.get())
-                        
-                    } else {
-                        unreachable!("2")
-                    }
-                
-            };
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::bool(
-            (current_route ==Numeric::from(0 ))
+        TypesCoproduct::__pax_stdCOCOtypesCOCOColor(
+            Color::rgb((Numeric::from(0.4)),(Numeric::from(0.5)),(Numeric::from(0)),)
         )
     }));
     
     //Transform2D::anchor(0%,0%)*Transform2D::align(0%,0%)
-    vtable.insert(3, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(2, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
 
         #[allow(unused_parens)]
         TypesCoproduct::Transform2D(
             (Transform2D::anchor((Size::Percent(0 .into())),(Size::Percent(0 .into())),)*(Transform2D::align((Size::Percent(0 .into())),(Size::Percent(0 .into())),)).into())
+        )
+    }));
+    
+    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
+    vtable.insert(3, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
         )
     }));
     
@@ -183,18 +145,8 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
         )
     }));
     
-    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
-    vtable.insert(6, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::Transform2D(
-            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
-        )
-    }));
-    
     //Transform2D::anchor(0%,0%)*Transform2D::align(0%,0%)
-    vtable.insert(7, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(6, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
 
         #[allow(unused_parens)]
@@ -204,7 +156,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     }));
     
     //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
-    vtable.insert(8, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(7, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
 
         #[allow(unused_parens)]
@@ -214,7 +166,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     }));
     
     //Color::rgba(0.0,0.0,0.0,1.0)
-    vtable.insert(9, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(8, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
 
         #[allow(unused_parens)]
@@ -224,7 +176,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     }));
     
     //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
-    vtable.insert(10, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(9, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
 
         #[allow(unused_parens)]
@@ -233,20 +185,10 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
         )
     }));
     
-    //Color::rgb(0.4,0.5,0)
-    vtable.insert(11, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    //current_route == 2 
+    vtable.insert(10, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
-
-        #[allow(unused_parens)]
-        TypesCoproduct::__pax_stdCOCOtypesCOCOColor(
-            Color::rgb((Numeric::from(0.4)),(Numeric::from(0.5)),(Numeric::from(0)),)
-        )
-    }));
-    
-    //Transform2D::align(50%,50%)*Transform2D::anchor(50%,50%)*Transform2D::rotate(rotation)
-    vtable.insert(12, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-            let rotation = {
+            let current_route = {
                 let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
                     Rc::clone(&sf)
                 } else {
@@ -255,9 +197,67 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
                 let properties = &*(*properties).borrow();
 
                 
-                    if let PropertiesCoproduct::HelloRGB(p) = properties {
+                    if let PropertiesCoproduct::Example(p) = properties {
                         
-                            Numeric::from(p.rotation.get())
+                            Numeric::from(p.current_route.get())
+                        
+                    } else {
+                        unreachable!("10")
+                    }
+                
+            };
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::bool(
+            (current_route ==Numeric::from(2 ))
+        )
+    }));
+    
+    //current_route == 1 
+    vtable.insert(11, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+            let current_route = {
+                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
+                    Rc::clone(&sf)
+                } else {
+                    Rc::clone(&ec.stack_frame)
+                }.borrow().deref().get_properties();
+                let properties = &*(*properties).borrow();
+
+                
+                    if let PropertiesCoproduct::Example(p) = properties {
+                        
+                            Numeric::from(p.current_route.get())
+                        
+                    } else {
+                        unreachable!("11")
+                    }
+                
+            };
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::bool(
+            (current_route ==Numeric::from(1 ))
+        )
+    }));
+    
+    //current_route == 0 
+    vtable.insert(12, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+            let current_route = {
+                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
+                    Rc::clone(&sf)
+                } else {
+                    Rc::clone(&ec.stack_frame)
+                }.borrow().deref().get_properties();
+                let properties = &*(*properties).borrow();
+
+                
+                    if let PropertiesCoproduct::Example(p) = properties {
+                        
+                            Numeric::from(p.current_route.get())
                         
                     } else {
                         unreachable!("12")
@@ -267,8 +267,8 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
         
 
         #[allow(unused_parens)]
-        TypesCoproduct::Transform2D(
-            ((Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())*(Transform2D::rotate((rotation),)).into())
+        TypesCoproduct::bool(
+            (current_route ==Numeric::from(0 ))
         )
     }));
     
@@ -410,6 +410,563 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
 //Begin component factory literals
 
     
+pub fn instantiate_component_HelloRGB<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
+    args.component_template = Some(Rc::new(RefCell::new(vec![
+
+pax_std_primitives::ellipse::EllipseInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Ellipse( Ellipse {
+        
+            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyExpression::new(1) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![|stack_frame, args|{
+                                                                    let properties = (*stack_frame).borrow().get_properties();
+                                                                    let properties = &mut *properties.as_ref().borrow_mut();
+                                                                    let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
+                                                                    HelloRGB::handle_click(properties,args);
+                                                                },],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![|stack_frame, args|{
+                                                                     let properties = (*stack_frame).borrow().get_properties();
+                                                                     let properties = &mut *properties.as_ref().borrow_mut();
+                                                                     let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
+                                                                     HelloRGB::handle_scroll(properties,args);
+                                                                 },],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(0))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Percent(50.into()))),Box::new(PropertyLiteral::new(Size::Percent(50.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+])));
+
+    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
+        click_handlers: vec![],
+        will_render_handlers: vec![],
+        did_mount_handlers: vec![],
+        scroll_handlers: vec![],
+    })));
+
+    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
+        let properties = &mut *properties.as_ref().borrow_mut();
+        let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
+
+        
+            if let Some(new_value) = rtc.compute_eased_value(properties.rotation._get_transition_manager()) {
+            properties.rotation.set(new_value);
+            } else if let Some(new_value) = rtc.compute_vtable_value(properties.rotation._get_vtable_id()) {
+            let new_value = if let TypesCoproduct::__f64(v) = new_value { v } else { unreachable!() };
+            properties.rotation.set(new_value);
+            }
+        
+    }));
+
+    ComponentInstance::instantiate(args)
+}
+
+
+
+
+    
+pub fn instantiate_component_Words<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
+    args.component_template = Some(Rc::new(RefCell::new(vec![
+
+pax_std_primitives::group::GroupInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Group( Group {
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Default::default())),Box::new(PropertyLiteral::new(Default::default()))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+            
+
+pax_std_primitives::text::TextInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Text( Text {
+        
+            text: Box::new( PropertyLiteral::new("Layer".try_into().unwrap()) ),
+        
+            font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::image::ImageInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Image( Image {
+        
+            path: Box::new( PropertyLiteral::new("assets/images/pax-logo.png".try_into().unwrap()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(2))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(280.into()))),Box::new(PropertyLiteral::new(Size::Pixels(120.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::image::ImageInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Image( Image {
+        
+            path: Box::new( PropertyLiteral::new("assets/images/jpeg_test.jpg".try_into().unwrap()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(3))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(500.into()))),Box::new(PropertyLiteral::new(Size::Pixels(500.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::text::TextInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Text( Text {
+        
+            text: Box::new( PropertyLiteral::new("apple".try_into().unwrap()) ),
+        
+            font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::rectangle::RectangleInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Rectangle( Rectangle {
+        
+            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyExpression::new(5) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(4))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(550.into()))),Box::new(PropertyLiteral::new(Size::Pixels(550.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::text::TextInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Text( Text {
+        
+            text: Box::new( PropertyLiteral::new("carrot".try_into().unwrap()) ),
+        
+            font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::image::ImageInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Image( Image {
+        
+            path: Box::new( PropertyLiteral::new("assets/images/pax-logo.png".try_into().unwrap()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(6))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(280.into()))),Box::new(PropertyLiteral::new(Size::Pixels(120.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::image::ImageInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Image( Image {
+        
+            path: Box::new( PropertyLiteral::new("assets/images/jpeg_test.jpg".try_into().unwrap()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(7))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(500.into()))),Box::new(PropertyLiteral::new(Size::Pixels(500.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::text::TextInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Text( Text {
+        
+            text: Box::new( PropertyLiteral::new("hello world".try_into().unwrap()) ),
+        
+            font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::rectangle::RectangleInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Rectangle( Rectangle {
+        
+            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyExpression::new(8) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(9))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(550.into()))),Box::new(PropertyLiteral::new(Size::Pixels(550.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+])));
+
+    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
+        click_handlers: vec![],
+        will_render_handlers: vec![],
+        did_mount_handlers: vec![],
+        scroll_handlers: vec![],
+    })));
+
+    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
+        let properties = &mut *properties.as_ref().borrow_mut();
+        let properties = if let PropertiesCoproduct::Words(p) = properties {p} else {unreachable!()};
+
+        
+    }));
+
+    ComponentInstance::instantiate(args)
+}
+
+
+
+
+    
 pub fn instantiate_root_component<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>) -> Rc<RefCell<ComponentInstance<R>>> {
     ComponentInstance::instantiate( InstantiationArgs{
         properties: PropertiesCoproduct::Example( Example::default() ),
@@ -515,7 +1072,7 @@ instantiate_component_Fireworks( Rc::clone(&instance_registry),
     slot_index: None,
     repeat_source_expression_vec: None,
     repeat_source_expression_range: None,
-    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(0))),
+    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(10))),
     compute_properties_fn: None,
 })
 ,
@@ -581,7 +1138,7 @@ instantiate_component_HelloRGB( Rc::clone(&instance_registry),
     slot_index: None,
     repeat_source_expression_vec: None,
     repeat_source_expression_range: None,
-    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(1))),
+    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(11))),
     compute_properties_fn: None,
 })
 ,
@@ -645,7 +1202,7 @@ instantiate_component_Words( Rc::clone(&instance_registry),
     slot_index: None,
     repeat_source_expression_vec: None,
     repeat_source_expression_range: None,
-    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(2))),
+    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(12))),
     compute_properties_fn: None,
 })
 ,
@@ -681,563 +1238,6 @@ instantiate_component_Words( Rc::clone(&instance_registry),
     })
 }
 
-
-
-
-
-    
-pub fn instantiate_component_Words<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
-    args.component_template = Some(Rc::new(RefCell::new(vec![
-
-pax_std_primitives::group::GroupInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Group( Group {
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Default::default())),Box::new(PropertyLiteral::new(Default::default()))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-            
-
-pax_std_primitives::text::TextInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Text( Text {
-        
-            text: Box::new( PropertyLiteral::new("Layer".try_into().unwrap()) ),
-        
-            font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::image::ImageInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Image( Image {
-        
-            path: Box::new( PropertyLiteral::new("assets/images/pax-logo.png".try_into().unwrap()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(3))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(280.into()))),Box::new(PropertyLiteral::new(Size::Pixels(120.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::image::ImageInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Image( Image {
-        
-            path: Box::new( PropertyLiteral::new("assets/images/jpeg_test.jpg".try_into().unwrap()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(4))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(500.into()))),Box::new(PropertyLiteral::new(Size::Pixels(500.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::text::TextInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Text( Text {
-        
-            text: Box::new( PropertyLiteral::new("apple".try_into().unwrap()) ),
-        
-            font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::rectangle::RectangleInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Rectangle( Rectangle {
-        
-            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyExpression::new(5) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(6))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(550.into()))),Box::new(PropertyLiteral::new(Size::Pixels(550.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::text::TextInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Text( Text {
-        
-            text: Box::new( PropertyLiteral::new("carrot".try_into().unwrap()) ),
-        
-            font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::image::ImageInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Image( Image {
-        
-            path: Box::new( PropertyLiteral::new("assets/images/pax-logo.png".try_into().unwrap()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(7))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(280.into()))),Box::new(PropertyLiteral::new(Size::Pixels(120.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::image::ImageInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Image( Image {
-        
-            path: Box::new( PropertyLiteral::new("assets/images/jpeg_test.jpg".try_into().unwrap()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(8))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(500.into()))),Box::new(PropertyLiteral::new(Size::Pixels(500.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::text::TextInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Text( Text {
-        
-            text: Box::new( PropertyLiteral::new("hello world".try_into().unwrap()) ),
-        
-            font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::rectangle::RectangleInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Rectangle( Rectangle {
-        
-            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyExpression::new(9) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(10))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(550.into()))),Box::new(PropertyLiteral::new(Size::Pixels(550.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-])));
-
-    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
-        click_handlers: vec![],
-        will_render_handlers: vec![],
-        did_mount_handlers: vec![],
-        scroll_handlers: vec![],
-    })));
-
-    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
-        let properties = &mut *properties.as_ref().borrow_mut();
-        let properties = if let PropertiesCoproduct::Words(p) = properties {p} else {unreachable!()};
-
-        
-    }));
-
-    ComponentInstance::instantiate(args)
-}
-
-
-
-
-    
-pub fn instantiate_component_HelloRGB<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
-    args.component_template = Some(Rc::new(RefCell::new(vec![
-
-pax_std_primitives::ellipse::EllipseInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Ellipse( Ellipse {
-        
-            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyExpression::new(11) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![|stack_frame, args|{
-                                                                    let properties = (*stack_frame).borrow().get_properties();
-                                                                    let properties = &mut *properties.as_ref().borrow_mut();
-                                                                    let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
-                                                                    HelloRGB::handle_click(properties,args);
-                                                                },],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![|stack_frame, args|{
-                                                                     let properties = (*stack_frame).borrow().get_properties();
-                                                                     let properties = &mut *properties.as_ref().borrow_mut();
-                                                                     let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
-                                                                     HelloRGB::handle_scroll(properties,args);
-                                                                 },],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(12))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Percent(50.into()))),Box::new(PropertyLiteral::new(Size::Percent(50.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-])));
-
-    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
-        click_handlers: vec![],
-        will_render_handlers: vec![],
-        did_mount_handlers: vec![],
-        scroll_handlers: vec![],
-    })));
-
-    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
-        let properties = &mut *properties.as_ref().borrow_mut();
-        let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
-
-        
-            if let Some(new_value) = rtc.compute_eased_value(properties.rotation._get_transition_manager()) {
-            properties.rotation.set(new_value);
-            } else if let Some(new_value) = rtc.compute_vtable_value(properties.rotation._get_vtable_id()) {
-            let new_value = if let TypesCoproduct::__f64(v) = new_value { v } else { unreachable!() };
-            properties.rotation.set(new_value);
-            }
-        
-    }));
-
-    ComponentInstance::instantiate(args)
-}
 
 
 

--- a/pax-example/.pax/cartridge/src/lib.rs
+++ b/pax-example/.pax/cartridge/src/lib.rs
@@ -14,11 +14,27 @@ use piet_common::RenderContext;
 
 // generate imports, pointing to userland cartridge `pub mod pax_reexports`
 
+use pax_example::pax_reexports::core::option::Option;
+
 use pax_example::pax_reexports::f64;
 
 use pax_example::pax_reexports::pax_std::types::Color;
 
 use pax_example::pax_reexports::pax_std::types::Stroke;
+
+use pax_example::pax_reexports::pax_std::types::text::Font;
+
+use pax_example::pax_reexports::pax_std::types::text::FontStyle;
+
+use pax_example::pax_reexports::pax_std::types::text::FontWeight;
+
+use pax_example::pax_reexports::pax_std::types::text::LinkStyle;
+
+use pax_example::pax_reexports::pax_std::types::text::SizeWrapper;
+
+use pax_example::pax_reexports::pax_std::types::text::TextAlignHorizontal;
+
+use pax_example::pax_reexports::pax_std::types::text::TextAlignVertical;
 
 use pax_example::pax_reexports::std::string::String;
 
@@ -38,6 +54,8 @@ use pax_example::pax_reexports::pax_std::primitives::Image;
 
 use pax_example::pax_reexports::pax_std::primitives::Rectangle;
 
+use pax_example::pax_reexports::pax_std::primitives::Text;
+
 use pax_example::pax_reexports::words::Words;
 
 
@@ -48,95 +66,8 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     let mut vtable: HashMap<usize, Box<dyn Fn(ExpressionContext<R>) -> TypesCoproduct>> = HashMap::new();
 
     
-    //current_route == 2 
-    vtable.insert(0, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-            let current_route = {
-                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
-                    Rc::clone(&sf)
-                } else {
-                    Rc::clone(&ec.stack_frame)
-                }.borrow().deref().get_properties();
-                let properties = &*(*properties).borrow();
-
-                
-                    if let PropertiesCoproduct::Example(p) = properties {
-                        
-                            Numeric::from(p.current_route.get())
-                        
-                    } else {
-                        unreachable!("0")
-                    }
-                
-            };
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::bool(
-            (current_route ==Numeric::from(2 ))
-        )
-    }));
-    
-    //current_route == 1 
-    vtable.insert(1, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-            let current_route = {
-                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
-                    Rc::clone(&sf)
-                } else {
-                    Rc::clone(&ec.stack_frame)
-                }.borrow().deref().get_properties();
-                let properties = &*(*properties).borrow();
-
-                
-                    if let PropertiesCoproduct::Example(p) = properties {
-                        
-                            Numeric::from(p.current_route.get())
-                        
-                    } else {
-                        unreachable!("1")
-                    }
-                
-            };
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::bool(
-            (current_route ==Numeric::from(1 ))
-        )
-    }));
-    
-    //current_route == 0 
-    vtable.insert(2, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-            let current_route = {
-                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
-                    Rc::clone(&sf)
-                } else {
-                    Rc::clone(&ec.stack_frame)
-                }.borrow().deref().get_properties();
-                let properties = &*(*properties).borrow();
-
-                
-                    if let PropertiesCoproduct::Example(p) = properties {
-                        
-                            Numeric::from(p.current_route.get())
-                        
-                    } else {
-                        unreachable!("2")
-                    }
-                
-            };
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::bool(
-            (current_route ==Numeric::from(0 ))
-        )
-    }));
-    
     //Color::rgb(0.4,0.5,0)
-    vtable.insert(3, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(0, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
 
         #[allow(unused_parens)]
@@ -146,7 +77,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     }));
     
     //Transform2D::align(50%,50%)*Transform2D::anchor(50%,50%)*Transform2D::rotate(rotation)
-    vtable.insert(4, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(1, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
             let rotation = {
                 let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
@@ -162,7 +93,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
                             Numeric::from(p.rotation.get())
                         
                     } else {
-                        unreachable!("4")
+                        unreachable!("1")
                     }
                 
             };
@@ -174,48 +105,8 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
         )
     }));
     
-    //Transform2D::anchor(0%,0%)*Transform2D::align(0%,0%)
-    vtable.insert(5, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::Transform2D(
-            (Transform2D::anchor((Size::Percent(0 .into())),(Size::Percent(0 .into())),)*(Transform2D::align((Size::Percent(0 .into())),(Size::Percent(0 .into())),)).into())
-        )
-    }));
-    
-    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
-    vtable.insert(6, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::Transform2D(
-            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
-        )
-    }));
-    
-    //Color::rgba(0.0,0.0,0.0,1.0)
-    vtable.insert(7, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::__pax_stdCOCOtypesCOCOColor(
-            Color::rgba((Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(1.0)),)
-        )
-    }));
-    
-    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
-    vtable.insert(8, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::Transform2D(
-            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
-        )
-    }));
-    
     //0 .. 60
-    vtable.insert(9, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(2, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
 
         #[allow(unused_parens)]
@@ -225,7 +116,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     }));
     
     //Color::hlc(ticks+i*360.0/30.0,75.0,150.0)
-    vtable.insert(10, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(3, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
             let ticks = {
                 let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(1) {
@@ -241,7 +132,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
                             Numeric::from(p.ticks.get())
                         
                     } else {
-                        unreachable!("10")
+                        unreachable!("3")
                     }
                 
             };
@@ -276,7 +167,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     }));
     
     //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)*Transform2D::rotate((i+2)*rotation+ticks/1000.0)*Transform2D::scale(0.75+(i*rotation),0.75+(i*rotation))*Transform2D::scale(1-((rotation/5)+i/1000.0),1-((rotation/5)+i/1000.0))
-    vtable.insert(11, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(4, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
             let i = {
                 let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
@@ -314,7 +205,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
                             Numeric::from(p.rotation.get())
                         
                     } else {
-                        unreachable!("11")
+                        unreachable!("4")
                     }
                 
             };
@@ -333,7 +224,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
                             Numeric::from(p.ticks.get())
                         
                     } else {
-                        unreachable!("11")
+                        unreachable!("4")
                     }
                 
             };
@@ -345,11 +236,883 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
         )
     }));
     
+    //Transform2D::anchor(0%,0%)*Transform2D::align(0%,0%)
+    vtable.insert(5, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            (Transform2D::anchor((Size::Percent(0 .into())),(Size::Percent(0 .into())),)*(Transform2D::align((Size::Percent(0 .into())),(Size::Percent(0 .into())),)).into())
+        )
+    }));
+    
+    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
+    vtable.insert(6, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
+        )
+    }));
+    
+    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
+    vtable.insert(7, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
+        )
+    }));
+    
+    //Color::rgba(0.0,0.0,0.0,1.0)
+    vtable.insert(8, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::__pax_stdCOCOtypesCOCOColor(
+            Color::rgba((Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(1.0)),)
+        )
+    }));
+    
+    //Transform2D::anchor(0%,0%)*Transform2D::align(0%,0%)
+    vtable.insert(9, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            (Transform2D::anchor((Size::Percent(0 .into())),(Size::Percent(0 .into())),)*(Transform2D::align((Size::Percent(0 .into())),(Size::Percent(0 .into())),)).into())
+        )
+    }));
+    
+    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
+    vtable.insert(10, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
+        )
+    }));
+    
+    //Color::rgba(0.0,0.0,0.0,1.0)
+    vtable.insert(11, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::__pax_stdCOCOtypesCOCOColor(
+            Color::rgba((Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(1.0)),)
+        )
+    }));
+    
+    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
+    vtable.insert(12, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
+        )
+    }));
+    
+    //current_route == 2 
+    vtable.insert(13, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+            let current_route = {
+                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
+                    Rc::clone(&sf)
+                } else {
+                    Rc::clone(&ec.stack_frame)
+                }.borrow().deref().get_properties();
+                let properties = &*(*properties).borrow();
+
+                
+                    if let PropertiesCoproduct::Example(p) = properties {
+                        
+                            Numeric::from(p.current_route.get())
+                        
+                    } else {
+                        unreachable!("13")
+                    }
+                
+            };
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::bool(
+            (current_route ==Numeric::from(2 ))
+        )
+    }));
+    
+    //current_route == 1 
+    vtable.insert(14, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+            let current_route = {
+                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
+                    Rc::clone(&sf)
+                } else {
+                    Rc::clone(&ec.stack_frame)
+                }.borrow().deref().get_properties();
+                let properties = &*(*properties).borrow();
+
+                
+                    if let PropertiesCoproduct::Example(p) = properties {
+                        
+                            Numeric::from(p.current_route.get())
+                        
+                    } else {
+                        unreachable!("14")
+                    }
+                
+            };
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::bool(
+            (current_route ==Numeric::from(1 ))
+        )
+    }));
+    
+    //current_route == 0 
+    vtable.insert(15, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+            let current_route = {
+                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
+                    Rc::clone(&sf)
+                } else {
+                    Rc::clone(&ec.stack_frame)
+                }.borrow().deref().get_properties();
+                let properties = &*(*properties).borrow();
+
+                
+                    if let PropertiesCoproduct::Example(p) = properties {
+                        
+                            Numeric::from(p.current_route.get())
+                        
+                    } else {
+                        unreachable!("15")
+                    }
+                
+            };
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::bool(
+            (current_route ==Numeric::from(0 ))
+        )
+    }));
+    
 
     vtable
 }
 
 //Begin component factory literals
+
+    
+pub fn instantiate_component_HelloRGB<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
+    args.component_template = Some(Rc::new(RefCell::new(vec![
+
+pax_std_primitives::ellipse::EllipseInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Ellipse( Ellipse {
+        
+            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyExpression::new(0) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![|stack_frame, args|{
+                                                                    let properties = (*stack_frame).borrow().get_properties();
+                                                                    let properties = &mut *properties.as_ref().borrow_mut();
+                                                                    let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
+                                                                    HelloRGB::handle_click(properties,args);
+                                                                },],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![|stack_frame, args|{
+                                                                     let properties = (*stack_frame).borrow().get_properties();
+                                                                     let properties = &mut *properties.as_ref().borrow_mut();
+                                                                     let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
+                                                                     HelloRGB::handle_scroll(properties,args);
+                                                                 },],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(1))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Percent(50.into()))),Box::new(PropertyLiteral::new(Size::Percent(50.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+])));
+
+    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
+        click_handlers: vec![],
+        will_render_handlers: vec![],
+        did_mount_handlers: vec![],
+        scroll_handlers: vec![],
+    })));
+
+    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
+        let properties = &mut *properties.as_ref().borrow_mut();
+        let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
+
+        
+            if let Some(new_value) = rtc.compute_eased_value(properties.rotation._get_transition_manager()) {
+            properties.rotation.set(new_value);
+            } else if let Some(new_value) = rtc.compute_vtable_value(properties.rotation._get_vtable_id()) {
+            let new_value = if let TypesCoproduct::__f64(v) = new_value { v } else { unreachable!() };
+            properties.rotation.set(new_value);
+            }
+        
+    }));
+
+    ComponentInstance::instantiate(args)
+}
+
+
+
+
+    
+pub fn instantiate_component_Fireworks<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
+    args.component_template = Some(Rc::new(RefCell::new(vec![
+
+pax_std_primitives::group::GroupInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Group( Group {
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![|stack_frame, args|{
+                                                                     let properties = (*stack_frame).borrow().get_properties();
+                                                                     let properties = &mut *properties.as_ref().borrow_mut();
+                                                                     let properties = if let PropertiesCoproduct::Fireworks(p) = properties {p} else {unreachable!()};
+                                                                     Fireworks::handle_scroll(properties,args);
+                                                                 },],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Default::default())),Box::new(PropertyLiteral::new(Default::default()))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+            
+
+RepeatInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::None,
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Default::default())),Box::new(PropertyLiteral::new(Default::default()))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+            
+
+pax_std_primitives::rectangle::RectangleInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Rectangle( Rectangle {
+        
+            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyExpression::new(3) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(4))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: Some(Box::new(PropertyExpression::new(2))),
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+])));
+
+    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
+        click_handlers: vec![],
+        will_render_handlers: vec![
+                 |properties, args|{
+                     let properties = &mut *properties.as_ref().borrow_mut();
+                     let properties = if let PropertiesCoproduct::Fireworks(p) = properties {p} else {unreachable!()};
+                     Fireworks::handle_will_render(properties,args);
+                 },
+             ],
+        did_mount_handlers: vec![],
+        scroll_handlers: vec![],
+    })));
+
+    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
+        let properties = &mut *properties.as_ref().borrow_mut();
+        let properties = if let PropertiesCoproduct::Fireworks(p) = properties {p} else {unreachable!()};
+
+        
+            if let Some(new_value) = rtc.compute_eased_value(properties.rotation._get_transition_manager()) {
+            properties.rotation.set(new_value);
+            } else if let Some(new_value) = rtc.compute_vtable_value(properties.rotation._get_vtable_id()) {
+            let new_value = if let TypesCoproduct::__f64(v) = new_value { v } else { unreachable!() };
+            properties.rotation.set(new_value);
+            }
+        
+            if let Some(new_value) = rtc.compute_eased_value(properties.ticks._get_transition_manager()) {
+            properties.ticks.set(new_value);
+            } else if let Some(new_value) = rtc.compute_vtable_value(properties.ticks._get_vtable_id()) {
+            let new_value = if let TypesCoproduct::__usize(v) = new_value { v } else { unreachable!() };
+            properties.ticks.set(new_value);
+            }
+        
+    }));
+
+    ComponentInstance::instantiate(args)
+}
+
+
+
+
+    
+pub fn instantiate_component_Words<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
+    args.component_template = Some(Rc::new(RefCell::new(vec![
+
+pax_std_primitives::group::GroupInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Group( Group {
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Default::default())),Box::new(PropertyLiteral::new(Default::default()))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+            
+
+pax_std_primitives::text::TextInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Text( Text {
+        
+            text: Box::new( PropertyLiteral::new("Layer".try_into().unwrap()) ),
+        
+            font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::image::ImageInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Image( Image {
+        
+            path: Box::new( PropertyLiteral::new("assets/images/pax-logo.png".try_into().unwrap()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(5))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(280.into()))),Box::new(PropertyLiteral::new(Size::Pixels(120.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::image::ImageInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Image( Image {
+        
+            path: Box::new( PropertyLiteral::new("assets/images/jpeg_test.jpg".try_into().unwrap()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(6))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(500.into()))),Box::new(PropertyLiteral::new(Size::Pixels(500.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::text::TextInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Text( Text {
+        
+            text: Box::new( PropertyLiteral::new("apple".try_into().unwrap()) ),
+        
+            font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::rectangle::RectangleInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Rectangle( Rectangle {
+        
+            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyExpression::new(8) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(7))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(550.into()))),Box::new(PropertyLiteral::new(Size::Pixels(550.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::text::TextInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Text( Text {
+        
+            text: Box::new( PropertyLiteral::new("carrot".try_into().unwrap()) ),
+        
+            font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::image::ImageInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Image( Image {
+        
+            path: Box::new( PropertyLiteral::new("assets/images/pax-logo.png".try_into().unwrap()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(9))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(280.into()))),Box::new(PropertyLiteral::new(Size::Pixels(120.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::image::ImageInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Image( Image {
+        
+            path: Box::new( PropertyLiteral::new("assets/images/jpeg_test.jpg".try_into().unwrap()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(10))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(500.into()))),Box::new(PropertyLiteral::new(Size::Pixels(500.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::text::TextInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Text( Text {
+        
+            text: Box::new( PropertyLiteral::new("hello world".try_into().unwrap()) ),
+        
+            font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::rectangle::RectangleInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Rectangle( Rectangle {
+        
+            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyExpression::new(11) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(12))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(550.into()))),Box::new(PropertyLiteral::new(Size::Pixels(550.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+])));
+
+    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
+        click_handlers: vec![],
+        will_render_handlers: vec![],
+        did_mount_handlers: vec![],
+        scroll_handlers: vec![],
+    })));
+
+    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
+        let properties = &mut *properties.as_ref().borrow_mut();
+        let properties = if let PropertiesCoproduct::Words(p) = properties {p} else {unreachable!()};
+
+        
+    }));
+
+    ComponentInstance::instantiate(args)
+}
+
+
+
 
     
 pub fn instantiate_root_component<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>) -> Rc<RefCell<ComponentInstance<R>>> {
@@ -457,7 +1220,7 @@ instantiate_component_Fireworks( Rc::clone(&instance_registry),
     slot_index: None,
     repeat_source_expression_vec: None,
     repeat_source_expression_range: None,
-    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(0))),
+    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(13))),
     compute_properties_fn: None,
 })
 ,
@@ -523,7 +1286,7 @@ instantiate_component_HelloRGB( Rc::clone(&instance_registry),
     slot_index: None,
     repeat_source_expression_vec: None,
     repeat_source_expression_range: None,
-    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(1))),
+    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(14))),
     compute_properties_fn: None,
 })
 ,
@@ -587,7 +1350,7 @@ instantiate_component_Words( Rc::clone(&instance_registry),
     slot_index: None,
     repeat_source_expression_vec: None,
     repeat_source_expression_range: None,
-    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(2))),
+    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(15))),
     compute_properties_fn: None,
 })
 ,
@@ -623,392 +1386,6 @@ instantiate_component_Words( Rc::clone(&instance_registry),
     })
 }
 
-
-
-
-
-    
-pub fn instantiate_component_HelloRGB<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
-    args.component_template = Some(Rc::new(RefCell::new(vec![
-
-pax_std_primitives::ellipse::EllipseInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Ellipse( Ellipse {
-        
-            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyExpression::new(3) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![|stack_frame, args|{
-                                                                    let properties = (*stack_frame).borrow().get_properties();
-                                                                    let properties = &mut *properties.as_ref().borrow_mut();
-                                                                    let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
-                                                                    HelloRGB::handle_click(properties,args);
-                                                                },],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![|stack_frame, args|{
-                                                                     let properties = (*stack_frame).borrow().get_properties();
-                                                                     let properties = &mut *properties.as_ref().borrow_mut();
-                                                                     let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
-                                                                     HelloRGB::handle_scroll(properties,args);
-                                                                 },],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(4))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Percent(50.into()))),Box::new(PropertyLiteral::new(Size::Percent(50.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-])));
-
-    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
-        click_handlers: vec![],
-        will_render_handlers: vec![],
-        did_mount_handlers: vec![],
-        scroll_handlers: vec![],
-    })));
-
-    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
-        let properties = &mut *properties.as_ref().borrow_mut();
-        let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
-
-        
-            if let Some(new_value) = rtc.compute_eased_value(properties.rotation._get_transition_manager()) {
-            properties.rotation.set(new_value);
-            } else if let Some(new_value) = rtc.compute_vtable_value(properties.rotation._get_vtable_id()) {
-            let new_value = if let TypesCoproduct::__f64(v) = new_value { v } else { unreachable!() };
-            properties.rotation.set(new_value);
-            }
-        
-    }));
-
-    ComponentInstance::instantiate(args)
-}
-
-
-
-
-    
-pub fn instantiate_component_Words<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
-    args.component_template = Some(Rc::new(RefCell::new(vec![
-
-pax_std_primitives::group::GroupInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Group( Group {
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Default::default())),Box::new(PropertyLiteral::new(Default::default()))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-            
-
-pax_std_primitives::image::ImageInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Image( Image {
-        
-            path: Box::new( PropertyLiteral::new("assets/images/pax-logo.png".try_into().unwrap()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(5))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(280.into()))),Box::new(PropertyLiteral::new(Size::Pixels(120.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::image::ImageInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Image( Image {
-        
-            path: Box::new( PropertyLiteral::new("assets/images/jpeg_test.jpg".try_into().unwrap()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(6))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(500.into()))),Box::new(PropertyLiteral::new(Size::Pixels(500.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::rectangle::RectangleInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Rectangle( Rectangle {
-        
-            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyExpression::new(7) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(8))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(550.into()))),Box::new(PropertyLiteral::new(Size::Pixels(550.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-])));
-
-    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
-        click_handlers: vec![],
-        will_render_handlers: vec![],
-        did_mount_handlers: vec![],
-        scroll_handlers: vec![],
-    })));
-
-    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
-        let properties = &mut *properties.as_ref().borrow_mut();
-        let properties = if let PropertiesCoproduct::Words(p) = properties {p} else {unreachable!()};
-
-        
-    }));
-
-    ComponentInstance::instantiate(args)
-}
-
-
-
-
-    
-pub fn instantiate_component_Fireworks<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
-    args.component_template = Some(Rc::new(RefCell::new(vec![
-
-pax_std_primitives::group::GroupInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Group( Group {
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![|stack_frame, args|{
-                                                                     let properties = (*stack_frame).borrow().get_properties();
-                                                                     let properties = &mut *properties.as_ref().borrow_mut();
-                                                                     let properties = if let PropertiesCoproduct::Fireworks(p) = properties {p} else {unreachable!()};
-                                                                     Fireworks::handle_scroll(properties,args);
-                                                                 },],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Default::default())),Box::new(PropertyLiteral::new(Default::default()))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-            
-
-RepeatInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::None,
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Default::default())),Box::new(PropertyLiteral::new(Default::default()))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-            
-
-pax_std_primitives::rectangle::RectangleInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Rectangle( Rectangle {
-        
-            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyExpression::new(10) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(11))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: Some(Box::new(PropertyExpression::new(9))),
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-])));
-
-    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
-        click_handlers: vec![],
-        will_render_handlers: vec![
-                 |properties, args|{
-                     let properties = &mut *properties.as_ref().borrow_mut();
-                     let properties = if let PropertiesCoproduct::Fireworks(p) = properties {p} else {unreachable!()};
-                     Fireworks::handle_will_render(properties,args);
-                 },
-             ],
-        did_mount_handlers: vec![],
-        scroll_handlers: vec![],
-    })));
-
-    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
-        let properties = &mut *properties.as_ref().borrow_mut();
-        let properties = if let PropertiesCoproduct::Fireworks(p) = properties {p} else {unreachable!()};
-
-        
-            if let Some(new_value) = rtc.compute_eased_value(properties.rotation._get_transition_manager()) {
-            properties.rotation.set(new_value);
-            } else if let Some(new_value) = rtc.compute_vtable_value(properties.rotation._get_vtable_id()) {
-            let new_value = if let TypesCoproduct::__f64(v) = new_value { v } else { unreachable!() };
-            properties.rotation.set(new_value);
-            }
-        
-            if let Some(new_value) = rtc.compute_eased_value(properties.ticks._get_transition_manager()) {
-            properties.ticks.set(new_value);
-            } else if let Some(new_value) = rtc.compute_vtable_value(properties.ticks._get_vtable_id()) {
-            let new_value = if let TypesCoproduct::__usize(v) = new_value { v } else { unreachable!() };
-            properties.ticks.set(new_value);
-            }
-        
-    }));
-
-    ComponentInstance::instantiate(args)
-}
 
 
 

--- a/pax-example/.pax/cartridge/src/lib.rs
+++ b/pax-example/.pax/cartridge/src/lib.rs
@@ -66,8 +66,88 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     let mut vtable: HashMap<usize, Box<dyn Fn(ExpressionContext<R>) -> TypesCoproduct>> = HashMap::new();
 
     
-    //Color::rgb(0.4,0.5,0)
+    //Transform2D::anchor(0%,0%)*Transform2D::align(0%,0%)
     vtable.insert(0, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            (Transform2D::anchor((Size::Percent(0 .into())),(Size::Percent(0 .into())),)*(Transform2D::align((Size::Percent(0 .into())),(Size::Percent(0 .into())),)).into())
+        )
+    }));
+    
+    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
+    vtable.insert(1, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
+        )
+    }));
+    
+    //Color::rgba(0.0,0.0,0.0,1.0)
+    vtable.insert(2, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::__pax_stdCOCOtypesCOCOColor(
+            Color::rgba((Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(1.0)),)
+        )
+    }));
+    
+    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
+    vtable.insert(3, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
+        )
+    }));
+    
+    //Transform2D::anchor(0%,0%)*Transform2D::align(0%,0%)
+    vtable.insert(4, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            (Transform2D::anchor((Size::Percent(0 .into())),(Size::Percent(0 .into())),)*(Transform2D::align((Size::Percent(0 .into())),(Size::Percent(0 .into())),)).into())
+        )
+    }));
+    
+    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
+    vtable.insert(5, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
+        )
+    }));
+    
+    //Color::rgba(0.0,0.0,0.0,1.0)
+    vtable.insert(6, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::__pax_stdCOCOtypesCOCOColor(
+            Color::rgba((Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(1.0)),)
+        )
+    }));
+    
+    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
+    vtable.insert(7, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
+        )
+    }));
+    
+    //Color::rgb(0.4,0.5,0)
+    vtable.insert(8, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
 
         #[allow(unused_parens)]
@@ -77,7 +157,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     }));
     
     //Transform2D::align(50%,50%)*Transform2D::anchor(50%,50%)*Transform2D::rotate(rotation)
-    vtable.insert(1, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(9, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
             let rotation = {
                 let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
@@ -93,7 +173,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
                             Numeric::from(p.rotation.get())
                         
                     } else {
-                        unreachable!("1")
+                        unreachable!("9")
                     }
                 
             };
@@ -105,8 +185,95 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
         )
     }));
     
+    //current_route == 2 
+    vtable.insert(10, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+            let current_route = {
+                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
+                    Rc::clone(&sf)
+                } else {
+                    Rc::clone(&ec.stack_frame)
+                }.borrow().deref().get_properties();
+                let properties = &*(*properties).borrow();
+
+                
+                    if let PropertiesCoproduct::Example(p) = properties {
+                        
+                            Numeric::from(p.current_route.get())
+                        
+                    } else {
+                        unreachable!("10")
+                    }
+                
+            };
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::bool(
+            (current_route ==Numeric::from(2 ))
+        )
+    }));
+    
+    //current_route == 1 
+    vtable.insert(11, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+            let current_route = {
+                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
+                    Rc::clone(&sf)
+                } else {
+                    Rc::clone(&ec.stack_frame)
+                }.borrow().deref().get_properties();
+                let properties = &*(*properties).borrow();
+
+                
+                    if let PropertiesCoproduct::Example(p) = properties {
+                        
+                            Numeric::from(p.current_route.get())
+                        
+                    } else {
+                        unreachable!("11")
+                    }
+                
+            };
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::bool(
+            (current_route ==Numeric::from(1 ))
+        )
+    }));
+    
+    //current_route == 0 
+    vtable.insert(12, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+            let current_route = {
+                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
+                    Rc::clone(&sf)
+                } else {
+                    Rc::clone(&ec.stack_frame)
+                }.borrow().deref().get_properties();
+                let properties = &*(*properties).borrow();
+
+                
+                    if let PropertiesCoproduct::Example(p) = properties {
+                        
+                            Numeric::from(p.current_route.get())
+                        
+                    } else {
+                        unreachable!("12")
+                    }
+                
+            };
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::bool(
+            (current_route ==Numeric::from(0 ))
+        )
+    }));
+    
     //0 .. 60
-    vtable.insert(2, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(13, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
 
         #[allow(unused_parens)]
@@ -116,7 +283,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     }));
     
     //Color::hlc(ticks+i*360.0/30.0,75.0,150.0)
-    vtable.insert(3, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(14, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
             let ticks = {
                 let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(1) {
@@ -132,7 +299,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
                             Numeric::from(p.ticks.get())
                         
                     } else {
-                        unreachable!("3")
+                        unreachable!("14")
                     }
                 
             };
@@ -167,7 +334,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     }));
     
     //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)*Transform2D::rotate((i+2)*rotation+ticks/1000.0)*Transform2D::scale(0.75+(i*rotation),0.75+(i*rotation))*Transform2D::scale(1-((rotation/5)+i/1000.0),1-((rotation/5)+i/1000.0))
-    vtable.insert(4, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(15, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
             let i = {
                 let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
@@ -205,7 +372,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
                             Numeric::from(p.rotation.get())
                         
                     } else {
-                        unreachable!("4")
+                        unreachable!("15")
                     }
                 
             };
@@ -224,7 +391,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
                             Numeric::from(p.ticks.get())
                         
                     } else {
-                        unreachable!("4")
+                        unreachable!("15")
                     }
                 
             };
@@ -236,402 +403,11 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
         )
     }));
     
-    //Transform2D::anchor(0%,0%)*Transform2D::align(0%,0%)
-    vtable.insert(5, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::Transform2D(
-            (Transform2D::anchor((Size::Percent(0 .into())),(Size::Percent(0 .into())),)*(Transform2D::align((Size::Percent(0 .into())),(Size::Percent(0 .into())),)).into())
-        )
-    }));
-    
-    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
-    vtable.insert(6, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::Transform2D(
-            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
-        )
-    }));
-    
-    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
-    vtable.insert(7, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::Transform2D(
-            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
-        )
-    }));
-    
-    //Color::rgba(0.0,0.0,0.0,1.0)
-    vtable.insert(8, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::__pax_stdCOCOtypesCOCOColor(
-            Color::rgba((Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(1.0)),)
-        )
-    }));
-    
-    //Transform2D::anchor(0%,0%)*Transform2D::align(0%,0%)
-    vtable.insert(9, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::Transform2D(
-            (Transform2D::anchor((Size::Percent(0 .into())),(Size::Percent(0 .into())),)*(Transform2D::align((Size::Percent(0 .into())),(Size::Percent(0 .into())),)).into())
-        )
-    }));
-    
-    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
-    vtable.insert(10, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::Transform2D(
-            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
-        )
-    }));
-    
-    //Color::rgba(0.0,0.0,0.0,1.0)
-    vtable.insert(11, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::__pax_stdCOCOtypesCOCOColor(
-            Color::rgba((Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(1.0)),)
-        )
-    }));
-    
-    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
-    vtable.insert(12, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::Transform2D(
-            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
-        )
-    }));
-    
-    //current_route == 2 
-    vtable.insert(13, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-            let current_route = {
-                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
-                    Rc::clone(&sf)
-                } else {
-                    Rc::clone(&ec.stack_frame)
-                }.borrow().deref().get_properties();
-                let properties = &*(*properties).borrow();
-
-                
-                    if let PropertiesCoproduct::Example(p) = properties {
-                        
-                            Numeric::from(p.current_route.get())
-                        
-                    } else {
-                        unreachable!("13")
-                    }
-                
-            };
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::bool(
-            (current_route ==Numeric::from(2 ))
-        )
-    }));
-    
-    //current_route == 1 
-    vtable.insert(14, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-            let current_route = {
-                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
-                    Rc::clone(&sf)
-                } else {
-                    Rc::clone(&ec.stack_frame)
-                }.borrow().deref().get_properties();
-                let properties = &*(*properties).borrow();
-
-                
-                    if let PropertiesCoproduct::Example(p) = properties {
-                        
-                            Numeric::from(p.current_route.get())
-                        
-                    } else {
-                        unreachable!("14")
-                    }
-                
-            };
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::bool(
-            (current_route ==Numeric::from(1 ))
-        )
-    }));
-    
-    //current_route == 0 
-    vtable.insert(15, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-            let current_route = {
-                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
-                    Rc::clone(&sf)
-                } else {
-                    Rc::clone(&ec.stack_frame)
-                }.borrow().deref().get_properties();
-                let properties = &*(*properties).borrow();
-
-                
-                    if let PropertiesCoproduct::Example(p) = properties {
-                        
-                            Numeric::from(p.current_route.get())
-                        
-                    } else {
-                        unreachable!("15")
-                    }
-                
-            };
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::bool(
-            (current_route ==Numeric::from(0 ))
-        )
-    }));
-    
 
     vtable
 }
 
 //Begin component factory literals
-
-    
-pub fn instantiate_component_HelloRGB<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
-    args.component_template = Some(Rc::new(RefCell::new(vec![
-
-pax_std_primitives::ellipse::EllipseInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Ellipse( Ellipse {
-        
-            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyExpression::new(0) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![|stack_frame, args|{
-                                                                    let properties = (*stack_frame).borrow().get_properties();
-                                                                    let properties = &mut *properties.as_ref().borrow_mut();
-                                                                    let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
-                                                                    HelloRGB::handle_click(properties,args);
-                                                                },],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![|stack_frame, args|{
-                                                                     let properties = (*stack_frame).borrow().get_properties();
-                                                                     let properties = &mut *properties.as_ref().borrow_mut();
-                                                                     let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
-                                                                     HelloRGB::handle_scroll(properties,args);
-                                                                 },],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(1))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Percent(50.into()))),Box::new(PropertyLiteral::new(Size::Percent(50.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-])));
-
-    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
-        click_handlers: vec![],
-        will_render_handlers: vec![],
-        did_mount_handlers: vec![],
-        scroll_handlers: vec![],
-    })));
-
-    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
-        let properties = &mut *properties.as_ref().borrow_mut();
-        let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
-
-        
-            if let Some(new_value) = rtc.compute_eased_value(properties.rotation._get_transition_manager()) {
-            properties.rotation.set(new_value);
-            } else if let Some(new_value) = rtc.compute_vtable_value(properties.rotation._get_vtable_id()) {
-            let new_value = if let TypesCoproduct::__f64(v) = new_value { v } else { unreachable!() };
-            properties.rotation.set(new_value);
-            }
-        
-    }));
-
-    ComponentInstance::instantiate(args)
-}
-
-
-
-
-    
-pub fn instantiate_component_Fireworks<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
-    args.component_template = Some(Rc::new(RefCell::new(vec![
-
-pax_std_primitives::group::GroupInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Group( Group {
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![|stack_frame, args|{
-                                                                     let properties = (*stack_frame).borrow().get_properties();
-                                                                     let properties = &mut *properties.as_ref().borrow_mut();
-                                                                     let properties = if let PropertiesCoproduct::Fireworks(p) = properties {p} else {unreachable!()};
-                                                                     Fireworks::handle_scroll(properties,args);
-                                                                 },],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Default::default())),Box::new(PropertyLiteral::new(Default::default()))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-            
-
-RepeatInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::None,
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Default::default())),Box::new(PropertyLiteral::new(Default::default()))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-            
-
-pax_std_primitives::rectangle::RectangleInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Rectangle( Rectangle {
-        
-            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyExpression::new(3) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(4))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: Some(Box::new(PropertyExpression::new(2))),
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-])));
-
-    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
-        click_handlers: vec![],
-        will_render_handlers: vec![
-                 |properties, args|{
-                     let properties = &mut *properties.as_ref().borrow_mut();
-                     let properties = if let PropertiesCoproduct::Fireworks(p) = properties {p} else {unreachable!()};
-                     Fireworks::handle_will_render(properties,args);
-                 },
-             ],
-        did_mount_handlers: vec![],
-        scroll_handlers: vec![],
-    })));
-
-    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
-        let properties = &mut *properties.as_ref().borrow_mut();
-        let properties = if let PropertiesCoproduct::Fireworks(p) = properties {p} else {unreachable!()};
-
-        
-            if let Some(new_value) = rtc.compute_eased_value(properties.rotation._get_transition_manager()) {
-            properties.rotation.set(new_value);
-            } else if let Some(new_value) = rtc.compute_vtable_value(properties.rotation._get_vtable_id()) {
-            let new_value = if let TypesCoproduct::__f64(v) = new_value { v } else { unreachable!() };
-            properties.rotation.set(new_value);
-            }
-        
-            if let Some(new_value) = rtc.compute_eased_value(properties.ticks._get_transition_manager()) {
-            properties.ticks.set(new_value);
-            } else if let Some(new_value) = rtc.compute_vtable_value(properties.ticks._get_vtable_id()) {
-            let new_value = if let TypesCoproduct::__usize(v) = new_value { v } else { unreachable!() };
-            properties.ticks.set(new_value);
-            }
-        
-    }));
-
-    ComponentInstance::instantiate(args)
-}
-
-
-
 
     
 pub fn instantiate_component_Words<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
@@ -728,7 +504,7 @@ pax_std_primitives::image::ImageInstance::instantiate(
                                                  }
                                              ))),
     instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(5))),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(0))),
     size: Some(Rc::new(RefCell::new(
         [Box::new(PropertyLiteral::new(Size::Pixels(280.into()))),Box::new(PropertyLiteral::new(Size::Pixels(120.into())))]
     ))),
@@ -763,7 +539,7 @@ pax_std_primitives::image::ImageInstance::instantiate(
                                                  }
                                              ))),
     instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(6))),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(1))),
     size: Some(Rc::new(RefCell::new(
         [Box::new(PropertyLiteral::new(Size::Pixels(500.into()))),Box::new(PropertyLiteral::new(Size::Pixels(500.into())))]
     ))),
@@ -841,7 +617,7 @@ pax_std_primitives::rectangle::RectangleInstance::instantiate(
         
             stroke: Box::new( PropertyLiteral::new(Default::default()) ),
         
-            fill: Box::new( PropertyExpression::new(8) ),
+            fill: Box::new( PropertyExpression::new(2) ),
         
     }),
     handler_registry:  Some(Rc::new(RefCell::new(
@@ -853,7 +629,7 @@ pax_std_primitives::rectangle::RectangleInstance::instantiate(
                                                  }
                                              ))),
     instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(7))),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(3))),
     size: Some(Rc::new(RefCell::new(
         [Box::new(PropertyLiteral::new(Size::Pixels(550.into()))),Box::new(PropertyLiteral::new(Size::Pixels(550.into())))]
     ))),
@@ -941,7 +717,7 @@ pax_std_primitives::image::ImageInstance::instantiate(
                                                  }
                                              ))),
     instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(9))),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(4))),
     size: Some(Rc::new(RefCell::new(
         [Box::new(PropertyLiteral::new(Size::Pixels(280.into()))),Box::new(PropertyLiteral::new(Size::Pixels(120.into())))]
     ))),
@@ -976,7 +752,7 @@ pax_std_primitives::image::ImageInstance::instantiate(
                                                  }
                                              ))),
     instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(10))),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(5))),
     size: Some(Rc::new(RefCell::new(
         [Box::new(PropertyLiteral::new(Size::Pixels(500.into()))),Box::new(PropertyLiteral::new(Size::Pixels(500.into())))]
     ))),
@@ -1054,7 +830,7 @@ pax_std_primitives::rectangle::RectangleInstance::instantiate(
         
             stroke: Box::new( PropertyLiteral::new(Default::default()) ),
         
-            fill: Box::new( PropertyExpression::new(11) ),
+            fill: Box::new( PropertyExpression::new(6) ),
         
     }),
     handler_registry:  Some(Rc::new(RefCell::new(
@@ -1066,7 +842,7 @@ pax_std_primitives::rectangle::RectangleInstance::instantiate(
                                                  }
                                              ))),
     instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(12))),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(7))),
     size: Some(Rc::new(RefCell::new(
         [Box::new(PropertyLiteral::new(Size::Pixels(550.into()))),Box::new(PropertyLiteral::new(Size::Pixels(550.into())))]
     ))),
@@ -1105,6 +881,82 @@ pax_std_primitives::rectangle::RectangleInstance::instantiate(
         let properties = &mut *properties.as_ref().borrow_mut();
         let properties = if let PropertiesCoproduct::Words(p) = properties {p} else {unreachable!()};
 
+        
+    }));
+
+    ComponentInstance::instantiate(args)
+}
+
+
+
+
+    
+pub fn instantiate_component_HelloRGB<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
+    args.component_template = Some(Rc::new(RefCell::new(vec![
+
+pax_std_primitives::ellipse::EllipseInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Ellipse( Ellipse {
+        
+            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyExpression::new(8) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![|stack_frame, args|{
+                                                                    let properties = (*stack_frame).borrow().get_properties();
+                                                                    let properties = &mut *properties.as_ref().borrow_mut();
+                                                                    let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
+                                                                    HelloRGB::handle_click(properties,args);
+                                                                },],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![|stack_frame, args|{
+                                                                     let properties = (*stack_frame).borrow().get_properties();
+                                                                     let properties = &mut *properties.as_ref().borrow_mut();
+                                                                     let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
+                                                                     HelloRGB::handle_scroll(properties,args);
+                                                                 },],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(9))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Percent(50.into()))),Box::new(PropertyLiteral::new(Size::Percent(50.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+])));
+
+    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
+        click_handlers: vec![],
+        will_render_handlers: vec![],
+        did_mount_handlers: vec![],
+        scroll_handlers: vec![],
+    })));
+
+    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
+        let properties = &mut *properties.as_ref().borrow_mut();
+        let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
+
+        
+            if let Some(new_value) = rtc.compute_eased_value(properties.rotation._get_transition_manager()) {
+            properties.rotation.set(new_value);
+            } else if let Some(new_value) = rtc.compute_vtable_value(properties.rotation._get_vtable_id()) {
+            let new_value = if let TypesCoproduct::__f64(v) = new_value { v } else { unreachable!() };
+            properties.rotation.set(new_value);
+            }
         
     }));
 
@@ -1220,7 +1072,7 @@ instantiate_component_Fireworks( Rc::clone(&instance_registry),
     slot_index: None,
     repeat_source_expression_vec: None,
     repeat_source_expression_range: None,
-    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(13))),
+    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(10))),
     compute_properties_fn: None,
 })
 ,
@@ -1286,7 +1138,7 @@ instantiate_component_HelloRGB( Rc::clone(&instance_registry),
     slot_index: None,
     repeat_source_expression_vec: None,
     repeat_source_expression_range: None,
-    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(14))),
+    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(11))),
     compute_properties_fn: None,
 })
 ,
@@ -1350,7 +1202,7 @@ instantiate_component_Words( Rc::clone(&instance_registry),
     slot_index: None,
     repeat_source_expression_vec: None,
     repeat_source_expression_range: None,
-    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(15))),
+    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(12))),
     compute_properties_fn: None,
 })
 ,
@@ -1386,6 +1238,154 @@ instantiate_component_Words( Rc::clone(&instance_registry),
     })
 }
 
+
+
+
+
+    
+pub fn instantiate_component_Fireworks<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
+    args.component_template = Some(Rc::new(RefCell::new(vec![
+
+pax_std_primitives::group::GroupInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Group( Group {
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![|stack_frame, args|{
+                                                                     let properties = (*stack_frame).borrow().get_properties();
+                                                                     let properties = &mut *properties.as_ref().borrow_mut();
+                                                                     let properties = if let PropertiesCoproduct::Fireworks(p) = properties {p} else {unreachable!()};
+                                                                     Fireworks::handle_scroll(properties,args);
+                                                                 },],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Default::default())),Box::new(PropertyLiteral::new(Default::default()))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+            
+
+RepeatInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::None,
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Default::default())),Box::new(PropertyLiteral::new(Default::default()))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+            
+
+pax_std_primitives::rectangle::RectangleInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Rectangle( Rectangle {
+        
+            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyExpression::new(14) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(15))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: Some(Box::new(PropertyExpression::new(13))),
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+])));
+
+    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
+        click_handlers: vec![],
+        will_render_handlers: vec![
+                 |properties, args|{
+                     let properties = &mut *properties.as_ref().borrow_mut();
+                     let properties = if let PropertiesCoproduct::Fireworks(p) = properties {p} else {unreachable!()};
+                     Fireworks::handle_will_render(properties,args);
+                 },
+             ],
+        did_mount_handlers: vec![],
+        scroll_handlers: vec![],
+    })));
+
+    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
+        let properties = &mut *properties.as_ref().borrow_mut();
+        let properties = if let PropertiesCoproduct::Fireworks(p) = properties {p} else {unreachable!()};
+
+        
+            if let Some(new_value) = rtc.compute_eased_value(properties.rotation._get_transition_manager()) {
+            properties.rotation.set(new_value);
+            } else if let Some(new_value) = rtc.compute_vtable_value(properties.rotation._get_vtable_id()) {
+            let new_value = if let TypesCoproduct::__f64(v) = new_value { v } else { unreachable!() };
+            properties.rotation.set(new_value);
+            }
+        
+            if let Some(new_value) = rtc.compute_eased_value(properties.ticks._get_transition_manager()) {
+            properties.ticks.set(new_value);
+            } else if let Some(new_value) = rtc.compute_vtable_value(properties.ticks._get_vtable_id()) {
+            let new_value = if let TypesCoproduct::__usize(v) = new_value { v } else { unreachable!() };
+            properties.ticks.set(new_value);
+            }
+        
+    }));
+
+    ComponentInstance::instantiate(args)
+}
 
 
 

--- a/pax-example/.pax/cartridge/src/lib.rs
+++ b/pax-example/.pax/cartridge/src/lib.rs
@@ -66,58 +66,105 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     let mut vtable: HashMap<usize, Box<dyn Fn(ExpressionContext<R>) -> TypesCoproduct>> = HashMap::new();
 
     
-    //Transform2D::anchor(0%,0%)*Transform2D::align(0%,0%)
+    //current_route == 2 
     vtable.insert(0, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
+            let current_route = {
+                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
+                    Rc::clone(&sf)
+                } else {
+                    Rc::clone(&ec.stack_frame)
+                }.borrow().deref().get_properties();
+                let properties = &*(*properties).borrow();
+
+                
+                    if let PropertiesCoproduct::Example(p) = properties {
+                        
+                            Numeric::from(p.current_route.get())
+                        
+                    } else {
+                        unreachable!("0")
+                    }
+                
+            };
+        
 
         #[allow(unused_parens)]
-        TypesCoproduct::Transform2D(
-            (Transform2D::anchor((Size::Percent(0 .into())),(Size::Percent(0 .into())),)*(Transform2D::align((Size::Percent(0 .into())),(Size::Percent(0 .into())),)).into())
+        TypesCoproduct::bool(
+            (current_route ==Numeric::from(2 ))
         )
     }));
     
-    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
+    //current_route == 1 
     vtable.insert(1, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
+            let current_route = {
+                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
+                    Rc::clone(&sf)
+                } else {
+                    Rc::clone(&ec.stack_frame)
+                }.borrow().deref().get_properties();
+                let properties = &*(*properties).borrow();
 
-        #[allow(unused_parens)]
-        TypesCoproduct::Transform2D(
-            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
-        )
-    }));
-    
-    //Color::rgba(0.0,0.0,0.0,1.0)
-    vtable.insert(2, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+                
+                    if let PropertiesCoproduct::Example(p) = properties {
+                        
+                            Numeric::from(p.current_route.get())
+                        
+                    } else {
+                        unreachable!("1")
+                    }
+                
+            };
         
 
         #[allow(unused_parens)]
-        TypesCoproduct::__pax_stdCOCOtypesCOCOColor(
-            Color::rgba((Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(1.0)),)
+        TypesCoproduct::bool(
+            (current_route ==Numeric::from(1 ))
         )
     }));
     
-    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
+    //current_route == 0 
+    vtable.insert(2, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+            let current_route = {
+                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
+                    Rc::clone(&sf)
+                } else {
+                    Rc::clone(&ec.stack_frame)
+                }.borrow().deref().get_properties();
+                let properties = &*(*properties).borrow();
+
+                
+                    if let PropertiesCoproduct::Example(p) = properties {
+                        
+                            Numeric::from(p.current_route.get())
+                        
+                    } else {
+                        unreachable!("2")
+                    }
+                
+            };
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::bool(
+            (current_route ==Numeric::from(0 ))
+        )
+    }));
+    
+    //Transform2D::anchor(0%,0%)*Transform2D::align(0%,0%)
     vtable.insert(3, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
 
         #[allow(unused_parens)]
         TypesCoproduct::Transform2D(
-            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
-        )
-    }));
-    
-    //Transform2D::anchor(0%,0%)*Transform2D::align(0%,0%)
-    vtable.insert(4, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::Transform2D(
             (Transform2D::anchor((Size::Percent(0 .into())),(Size::Percent(0 .into())),)*(Transform2D::align((Size::Percent(0 .into())),(Size::Percent(0 .into())),)).into())
         )
     }));
     
     //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
-    vtable.insert(5, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(4, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
 
         #[allow(unused_parens)]
@@ -127,7 +174,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     }));
     
     //Color::rgba(0.0,0.0,0.0,1.0)
-    vtable.insert(6, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(5, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
 
         #[allow(unused_parens)]
@@ -137,7 +184,47 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     }));
     
     //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
+    vtable.insert(6, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
+        )
+    }));
+    
+    //Transform2D::anchor(0%,0%)*Transform2D::align(0%,0%)
     vtable.insert(7, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            (Transform2D::anchor((Size::Percent(0 .into())),(Size::Percent(0 .into())),)*(Transform2D::align((Size::Percent(0 .into())),(Size::Percent(0 .into())),)).into())
+        )
+    }));
+    
+    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
+    vtable.insert(8, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            (Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())
+        )
+    }));
+    
+    //Color::rgba(0.0,0.0,0.0,1.0)
+    vtable.insert(9, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::__pax_stdCOCOtypesCOCOColor(
+            Color::rgba((Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(0.0)),(Numeric::from(1.0)),)
+        )
+    }));
+    
+    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)
+    vtable.insert(10, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
 
         #[allow(unused_parens)]
@@ -147,7 +234,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     }));
     
     //Color::rgb(0.4,0.5,0)
-    vtable.insert(8, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(11, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
 
         #[allow(unused_parens)]
@@ -157,7 +244,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
     }));
     
     //Transform2D::align(50%,50%)*Transform2D::anchor(50%,50%)*Transform2D::rotate(rotation)
-    vtable.insert(9, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+    vtable.insert(12, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
         
             let rotation = {
                 let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
@@ -173,7 +260,7 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
                             Numeric::from(p.rotation.get())
                         
                     } else {
-                        unreachable!("9")
+                        unreachable!("12")
                     }
                 
             };
@@ -182,93 +269,6 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
         #[allow(unused_parens)]
         TypesCoproduct::Transform2D(
             ((Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())*(Transform2D::rotate((rotation),)).into())
-        )
-    }));
-    
-    //current_route == 2 
-    vtable.insert(10, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-            let current_route = {
-                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
-                    Rc::clone(&sf)
-                } else {
-                    Rc::clone(&ec.stack_frame)
-                }.borrow().deref().get_properties();
-                let properties = &*(*properties).borrow();
-
-                
-                    if let PropertiesCoproduct::Example(p) = properties {
-                        
-                            Numeric::from(p.current_route.get())
-                        
-                    } else {
-                        unreachable!("10")
-                    }
-                
-            };
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::bool(
-            (current_route ==Numeric::from(2 ))
-        )
-    }));
-    
-    //current_route == 1 
-    vtable.insert(11, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-            let current_route = {
-                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
-                    Rc::clone(&sf)
-                } else {
-                    Rc::clone(&ec.stack_frame)
-                }.borrow().deref().get_properties();
-                let properties = &*(*properties).borrow();
-
-                
-                    if let PropertiesCoproduct::Example(p) = properties {
-                        
-                            Numeric::from(p.current_route.get())
-                        
-                    } else {
-                        unreachable!("11")
-                    }
-                
-            };
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::bool(
-            (current_route ==Numeric::from(1 ))
-        )
-    }));
-    
-    //current_route == 0 
-    vtable.insert(12, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-            let current_route = {
-                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
-                    Rc::clone(&sf)
-                } else {
-                    Rc::clone(&ec.stack_frame)
-                }.borrow().deref().get_properties();
-                let properties = &*(*properties).borrow();
-
-                
-                    if let PropertiesCoproduct::Example(p) = properties {
-                        
-                            Numeric::from(p.current_route.get())
-                        
-                    } else {
-                        unreachable!("12")
-                    }
-                
-            };
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::bool(
-            (current_route ==Numeric::from(0 ))
         )
     }));
     
@@ -282,8 +282,49 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
         )
     }));
     
-    //Color::hlc(ticks+i*360.0/30.0,75.0,150.0)
+    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)*Transform2D::rotate((i+2)*rotation+ticks/1000.0)*Transform2D::scale(0.75+(i*rotation),0.75+(i*rotation))*Transform2D::scale(1-((rotation/5)+i/1000.0),1-((rotation/5)+i/1000.0))
     vtable.insert(14, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+            let i = {
+                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
+                    Rc::clone(&sf)
+                } else {
+                    Rc::clone(&ec.stack_frame)
+                }.borrow().deref().get_properties();
+                let properties = &*(*properties).borrow();
+
+                
+                    if let PropertiesCoproduct::RepeatItem(elem, i) = properties {
+                        
+                            
+                                
+                                let unwrapped = if let PropertiesCoproduct::isize(i) = **elem {i} else {unreachable!()};
+                                Numeric::from(unwrapped)
+                            
+                        
+
+                    } else {unreachable!()}
+                
+            };
+        
+            let rotation = {
+                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(1) {
+                    Rc::clone(&sf)
+                } else {
+                    Rc::clone(&ec.stack_frame)
+                }.borrow().deref().get_properties();
+                let properties = &*(*properties).borrow();
+
+                
+                    if let PropertiesCoproduct::Fireworks(p) = properties {
+                        
+                            Numeric::from(p.rotation.get())
+                        
+                    } else {
+                        unreachable!("14")
+                    }
+                
+            };
         
             let ticks = {
                 let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(1) {
@@ -300,6 +341,35 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
                         
                     } else {
                         unreachable!("14")
+                    }
+                
+            };
+        
+
+        #[allow(unused_parens)]
+        TypesCoproduct::Transform2D(
+            ((((Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())*(Transform2D::rotate(((((i +Numeric::from(2))*(rotation ).into())+(ticks /Numeric::from(1000.0)))),)).into())*(Transform2D::scale(((Numeric::from(0.75)+(i *(rotation).into()))),((Numeric::from(0.75)+(i *(rotation).into()))),)).into())*(Transform2D::scale(((Numeric::from(1 )-((rotation /Numeric::from(5))+(i /Numeric::from(1000.0))))),((Numeric::from(1 )-((rotation /Numeric::from(5))+(i /Numeric::from(1000.0))))),)).into())
+        )
+    }));
+    
+    //Color::hlc(ticks+i*360.0/30.0,75.0,150.0)
+    vtable.insert(15, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
+        
+            let ticks = {
+                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(1) {
+                    Rc::clone(&sf)
+                } else {
+                    Rc::clone(&ec.stack_frame)
+                }.borrow().deref().get_properties();
+                let properties = &*(*properties).borrow();
+
+                
+                    if let PropertiesCoproduct::Fireworks(p) = properties {
+                        
+                            Numeric::from(p.ticks.get())
+                        
+                    } else {
+                        unreachable!("15")
                     }
                 
             };
@@ -333,638 +403,11 @@ pub fn instantiate_expression_table<R: 'static + RenderContext>() -> HashMap<usi
         )
     }));
     
-    //Transform2D::anchor(50%,50%)*Transform2D::align(50%,50%)*Transform2D::rotate((i+2)*rotation+ticks/1000.0)*Transform2D::scale(0.75+(i*rotation),0.75+(i*rotation))*Transform2D::scale(1-((rotation/5)+i/1000.0),1-((rotation/5)+i/1000.0))
-    vtable.insert(15, Box::new(|ec: ExpressionContext<R>| -> TypesCoproduct {
-        
-            let i = {
-                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(0) {
-                    Rc::clone(&sf)
-                } else {
-                    Rc::clone(&ec.stack_frame)
-                }.borrow().deref().get_properties();
-                let properties = &*(*properties).borrow();
-
-                
-                    if let PropertiesCoproduct::RepeatItem(elem, i) = properties {
-                        
-                            
-                                
-                                let unwrapped = if let PropertiesCoproduct::isize(i) = **elem {i} else {unreachable!()};
-                                Numeric::from(unwrapped)
-                            
-                        
-
-                    } else {unreachable!()}
-                
-            };
-        
-            let rotation = {
-                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(1) {
-                    Rc::clone(&sf)
-                } else {
-                    Rc::clone(&ec.stack_frame)
-                }.borrow().deref().get_properties();
-                let properties = &*(*properties).borrow();
-
-                
-                    if let PropertiesCoproduct::Fireworks(p) = properties {
-                        
-                            Numeric::from(p.rotation.get())
-                        
-                    } else {
-                        unreachable!("15")
-                    }
-                
-            };
-        
-            let ticks = {
-                let properties = if let Some(sf) = (*ec.stack_frame).borrow().peek_nth(1) {
-                    Rc::clone(&sf)
-                } else {
-                    Rc::clone(&ec.stack_frame)
-                }.borrow().deref().get_properties();
-                let properties = &*(*properties).borrow();
-
-                
-                    if let PropertiesCoproduct::Fireworks(p) = properties {
-                        
-                            Numeric::from(p.ticks.get())
-                        
-                    } else {
-                        unreachable!("15")
-                    }
-                
-            };
-        
-
-        #[allow(unused_parens)]
-        TypesCoproduct::Transform2D(
-            ((((Transform2D::anchor((Size::Percent(50.into())),(Size::Percent(50.into())),)*(Transform2D::align((Size::Percent(50.into())),(Size::Percent(50.into())),)).into())*(Transform2D::rotate(((((i +Numeric::from(2))*(rotation ).into())+(ticks /Numeric::from(1000.0)))),)).into())*(Transform2D::scale(((Numeric::from(0.75)+(i *(rotation).into()))),((Numeric::from(0.75)+(i *(rotation).into()))),)).into())*(Transform2D::scale(((Numeric::from(1 )-((rotation /Numeric::from(5))+(i /Numeric::from(1000.0))))),((Numeric::from(1 )-((rotation /Numeric::from(5))+(i /Numeric::from(1000.0))))),)).into())
-        )
-    }));
-    
 
     vtable
 }
 
 //Begin component factory literals
-
-    
-pub fn instantiate_component_Words<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
-    args.component_template = Some(Rc::new(RefCell::new(vec![
-
-pax_std_primitives::group::GroupInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Group( Group {
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Default::default())),Box::new(PropertyLiteral::new(Default::default()))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-            
-
-pax_std_primitives::text::TextInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Text( Text {
-        
-            text: Box::new( PropertyLiteral::new("Layer".try_into().unwrap()) ),
-        
-            font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::image::ImageInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Image( Image {
-        
-            path: Box::new( PropertyLiteral::new("assets/images/pax-logo.png".try_into().unwrap()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(0))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(280.into()))),Box::new(PropertyLiteral::new(Size::Pixels(120.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::image::ImageInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Image( Image {
-        
-            path: Box::new( PropertyLiteral::new("assets/images/jpeg_test.jpg".try_into().unwrap()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(1))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(500.into()))),Box::new(PropertyLiteral::new(Size::Pixels(500.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::text::TextInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Text( Text {
-        
-            text: Box::new( PropertyLiteral::new("apple".try_into().unwrap()) ),
-        
-            font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::rectangle::RectangleInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Rectangle( Rectangle {
-        
-            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyExpression::new(2) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(3))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(550.into()))),Box::new(PropertyLiteral::new(Size::Pixels(550.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::text::TextInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Text( Text {
-        
-            text: Box::new( PropertyLiteral::new("carrot".try_into().unwrap()) ),
-        
-            font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::image::ImageInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Image( Image {
-        
-            path: Box::new( PropertyLiteral::new("assets/images/pax-logo.png".try_into().unwrap()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(4))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(280.into()))),Box::new(PropertyLiteral::new(Size::Pixels(120.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::image::ImageInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Image( Image {
-        
-            path: Box::new( PropertyLiteral::new("assets/images/jpeg_test.jpg".try_into().unwrap()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(5))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(500.into()))),Box::new(PropertyLiteral::new(Size::Pixels(500.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::text::TextInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Text( Text {
-        
-            text: Box::new( PropertyLiteral::new("hello world".try_into().unwrap()) ),
-        
-            font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-            
-
-pax_std_primitives::rectangle::RectangleInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Rectangle( Rectangle {
-        
-            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyExpression::new(6) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(7))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Pixels(550.into()))),Box::new(PropertyLiteral::new(Size::Pixels(550.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-,
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-])));
-
-    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
-        click_handlers: vec![],
-        will_render_handlers: vec![],
-        did_mount_handlers: vec![],
-        scroll_handlers: vec![],
-    })));
-
-    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
-        let properties = &mut *properties.as_ref().borrow_mut();
-        let properties = if let PropertiesCoproduct::Words(p) = properties {p} else {unreachable!()};
-
-        
-    }));
-
-    ComponentInstance::instantiate(args)
-}
-
-
-
-
-    
-pub fn instantiate_component_HelloRGB<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
-    args.component_template = Some(Rc::new(RefCell::new(vec![
-
-pax_std_primitives::ellipse::EllipseInstance::instantiate(
- InstantiationArgs {
-    properties: PropertiesCoproduct::Ellipse( Ellipse {
-        
-            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
-        
-            fill: Box::new( PropertyExpression::new(8) ),
-        
-    }),
-    handler_registry:  Some(Rc::new(RefCell::new(
-                                                 HandlerRegistry {
-                                                     click_handlers: vec![|stack_frame, args|{
-                                                                    let properties = (*stack_frame).borrow().get_properties();
-                                                                    let properties = &mut *properties.as_ref().borrow_mut();
-                                                                    let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
-                                                                    HelloRGB::handle_click(properties,args);
-                                                                },],
-                                                     will_render_handlers: vec![],
-                                                     did_mount_handlers: vec![],
-                                                     scroll_handlers: vec![|stack_frame, args|{
-                                                                     let properties = (*stack_frame).borrow().get_properties();
-                                                                     let properties = &mut *properties.as_ref().borrow_mut();
-                                                                     let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
-                                                                     HelloRGB::handle_scroll(properties,args);
-                                                                 },],
-                                                 }
-                                             ))),
-    instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(9))),
-    size: Some(Rc::new(RefCell::new(
-        [Box::new(PropertyLiteral::new(Size::Percent(50.into()))),Box::new(PropertyLiteral::new(Size::Percent(50.into())))]
-    ))),
-    children: Some(Rc::new(RefCell::new(vec![
-        
-    ]))),
-    component_template: None,
-    scroller_args: None,
-    slot_index: None,
-    repeat_source_expression_vec: None,
-    repeat_source_expression_range: None,
-    conditional_boolean_expression: None,
-    compute_properties_fn: None,
-})
-])));
-
-    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
-        click_handlers: vec![],
-        will_render_handlers: vec![],
-        did_mount_handlers: vec![],
-        scroll_handlers: vec![],
-    })));
-
-    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
-        let properties = &mut *properties.as_ref().borrow_mut();
-        let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
-
-        
-            if let Some(new_value) = rtc.compute_eased_value(properties.rotation._get_transition_manager()) {
-            properties.rotation.set(new_value);
-            } else if let Some(new_value) = rtc.compute_vtable_value(properties.rotation._get_vtable_id()) {
-            let new_value = if let TypesCoproduct::__f64(v) = new_value { v } else { unreachable!() };
-            properties.rotation.set(new_value);
-            }
-        
-    }));
-
-    ComponentInstance::instantiate(args)
-}
-
-
-
 
     
 pub fn instantiate_root_component<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>) -> Rc<RefCell<ComponentInstance<R>>> {
@@ -1072,7 +515,7 @@ instantiate_component_Fireworks( Rc::clone(&instance_registry),
     slot_index: None,
     repeat_source_expression_vec: None,
     repeat_source_expression_range: None,
-    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(10))),
+    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(0))),
     compute_properties_fn: None,
 })
 ,
@@ -1138,7 +581,7 @@ instantiate_component_HelloRGB( Rc::clone(&instance_registry),
     slot_index: None,
     repeat_source_expression_vec: None,
     repeat_source_expression_range: None,
-    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(11))),
+    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(1))),
     compute_properties_fn: None,
 })
 ,
@@ -1202,7 +645,7 @@ instantiate_component_Words( Rc::clone(&instance_registry),
     slot_index: None,
     repeat_source_expression_vec: None,
     repeat_source_expression_range: None,
-    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(12))),
+    conditional_boolean_expression: Some(Box::new(PropertyExpression::new(2))),
     compute_properties_fn: None,
 })
 ,
@@ -1238,6 +681,563 @@ instantiate_component_Words( Rc::clone(&instance_registry),
     })
 }
 
+
+
+
+
+    
+pub fn instantiate_component_Words<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
+    args.component_template = Some(Rc::new(RefCell::new(vec![
+
+pax_std_primitives::group::GroupInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Group( Group {
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Default::default())),Box::new(PropertyLiteral::new(Default::default()))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+            
+
+pax_std_primitives::text::TextInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Text( Text {
+        
+            text: Box::new( PropertyLiteral::new("Layer".try_into().unwrap()) ),
+        
+            font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::image::ImageInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Image( Image {
+        
+            path: Box::new( PropertyLiteral::new("assets/images/pax-logo.png".try_into().unwrap()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(3))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(280.into()))),Box::new(PropertyLiteral::new(Size::Pixels(120.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::image::ImageInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Image( Image {
+        
+            path: Box::new( PropertyLiteral::new("assets/images/jpeg_test.jpg".try_into().unwrap()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(4))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(500.into()))),Box::new(PropertyLiteral::new(Size::Pixels(500.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::text::TextInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Text( Text {
+        
+            text: Box::new( PropertyLiteral::new("apple".try_into().unwrap()) ),
+        
+            font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::rectangle::RectangleInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Rectangle( Rectangle {
+        
+            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyExpression::new(5) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(6))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(550.into()))),Box::new(PropertyLiteral::new(Size::Pixels(550.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::text::TextInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Text( Text {
+        
+            text: Box::new( PropertyLiteral::new("carrot".try_into().unwrap()) ),
+        
+            font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::image::ImageInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Image( Image {
+        
+            path: Box::new( PropertyLiteral::new("assets/images/pax-logo.png".try_into().unwrap()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(7))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(280.into()))),Box::new(PropertyLiteral::new(Size::Pixels(120.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::image::ImageInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Image( Image {
+        
+            path: Box::new( PropertyLiteral::new("assets/images/jpeg_test.jpg".try_into().unwrap()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(8))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(500.into()))),Box::new(PropertyLiteral::new(Size::Pixels(500.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::text::TextInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Text( Text {
+        
+            text: Box::new( PropertyLiteral::new("hello world".try_into().unwrap()) ),
+        
+            font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            size_font: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            style_link: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_multiline: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_vertical: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            align_horizontal: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_weight: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            font_style: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyLiteral::new(Default::default()))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+            
+
+pax_std_primitives::rectangle::RectangleInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Rectangle( Rectangle {
+        
+            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyExpression::new(9) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(10))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Pixels(550.into()))),Box::new(PropertyLiteral::new(Size::Pixels(550.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+,
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+])));
+
+    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
+        click_handlers: vec![],
+        will_render_handlers: vec![],
+        did_mount_handlers: vec![],
+        scroll_handlers: vec![],
+    })));
+
+    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
+        let properties = &mut *properties.as_ref().borrow_mut();
+        let properties = if let PropertiesCoproduct::Words(p) = properties {p} else {unreachable!()};
+
+        
+    }));
+
+    ComponentInstance::instantiate(args)
+}
+
+
+
+
+    
+pub fn instantiate_component_HelloRGB<R: 'static + RenderContext>(instance_registry: Rc<RefCell<InstanceRegistry<R>>>, mut args: InstantiationArgs<R>) -> Rc<RefCell<ComponentInstance<R>>>  {
+    args.component_template = Some(Rc::new(RefCell::new(vec![
+
+pax_std_primitives::ellipse::EllipseInstance::instantiate(
+ InstantiationArgs {
+    properties: PropertiesCoproduct::Ellipse( Ellipse {
+        
+            stroke: Box::new( PropertyLiteral::new(Default::default()) ),
+        
+            fill: Box::new( PropertyExpression::new(11) ),
+        
+    }),
+    handler_registry:  Some(Rc::new(RefCell::new(
+                                                 HandlerRegistry {
+                                                     click_handlers: vec![|stack_frame, args|{
+                                                                    let properties = (*stack_frame).borrow().get_properties();
+                                                                    let properties = &mut *properties.as_ref().borrow_mut();
+                                                                    let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
+                                                                    HelloRGB::handle_click(properties,args);
+                                                                },],
+                                                     will_render_handlers: vec![],
+                                                     did_mount_handlers: vec![],
+                                                     scroll_handlers: vec![|stack_frame, args|{
+                                                                     let properties = (*stack_frame).borrow().get_properties();
+                                                                     let properties = &mut *properties.as_ref().borrow_mut();
+                                                                     let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
+                                                                     HelloRGB::handle_scroll(properties,args);
+                                                                 },],
+                                                 }
+                                             ))),
+    instance_registry: Rc::clone(&instance_registry),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(12))),
+    size: Some(Rc::new(RefCell::new(
+        [Box::new(PropertyLiteral::new(Size::Percent(50.into()))),Box::new(PropertyLiteral::new(Size::Percent(50.into())))]
+    ))),
+    children: Some(Rc::new(RefCell::new(vec![
+        
+    ]))),
+    component_template: None,
+    scroller_args: None,
+    slot_index: None,
+    repeat_source_expression_vec: None,
+    repeat_source_expression_range: None,
+    conditional_boolean_expression: None,
+    compute_properties_fn: None,
+})
+])));
+
+    args.handler_registry = Some(Rc::new(RefCell::new(HandlerRegistry {
+        click_handlers: vec![],
+        will_render_handlers: vec![],
+        did_mount_handlers: vec![],
+        scroll_handlers: vec![],
+    })));
+
+    args.compute_properties_fn = Some(Box::new(|properties, rtc|{
+        let properties = &mut *properties.as_ref().borrow_mut();
+        let properties = if let PropertiesCoproduct::HelloRGB(p) = properties {p} else {unreachable!()};
+
+        
+            if let Some(new_value) = rtc.compute_eased_value(properties.rotation._get_transition_manager()) {
+            properties.rotation.set(new_value);
+            } else if let Some(new_value) = rtc.compute_vtable_value(properties.rotation._get_vtable_id()) {
+            let new_value = if let TypesCoproduct::__f64(v) = new_value { v } else { unreachable!() };
+            properties.rotation.set(new_value);
+            }
+        
+    }));
+
+    ComponentInstance::instantiate(args)
+}
 
 
 
@@ -1299,7 +1299,7 @@ pax_std_primitives::rectangle::RectangleInstance::instantiate(
         
             stroke: Box::new( PropertyLiteral::new(Default::default()) ),
         
-            fill: Box::new( PropertyExpression::new(14) ),
+            fill: Box::new( PropertyExpression::new(15) ),
         
     }),
     handler_registry:  Some(Rc::new(RefCell::new(
@@ -1311,7 +1311,7 @@ pax_std_primitives::rectangle::RectangleInstance::instantiate(
                                                  }
                                              ))),
     instance_registry: Rc::clone(&instance_registry),
-    transform: Rc::new(RefCell::new(PropertyExpression::new(15))),
+    transform: Rc::new(RefCell::new(PropertyExpression::new(14))),
     size: Some(Rc::new(RefCell::new(
         [Box::new(PropertyLiteral::new(Size::Pixels(300.into()))),Box::new(PropertyLiteral::new(Size::Pixels(300.into())))]
     ))),

--- a/pax-example/.pax/properties-coproduct/src/lib.rs
+++ b/pax-example/.pax/properties-coproduct/src/lib.rs
@@ -25,6 +25,8 @@ pub enum PropertiesCoproduct {
     
     Rectangle(pax_example::pax_reexports::pax_std::primitives::Rectangle),
     
+    Text(pax_example::pax_reexports::pax_std::primitives::Text),
+    
     Words(pax_example::pax_reexports::words::Words),
     
 }
@@ -32,6 +34,10 @@ pub enum PropertiesCoproduct {
 //used namely for return types of expressions — may have other purposes
 #[repr(u32)]
 pub enum TypesCoproduct {
+    
+    OptionLABR__pax_stdCOCOtypesCOCOtextCOCOLinkStyleRABR(Option<pax_example::pax_reexports::pax_std::types::text::LinkStyle>),
+    
+    OptionLABR__pax_stdCOCOtypesCOCOtextCOCOTextAlignHorizontalRABR(Option<pax_example::pax_reexports::pax_std::types::text::TextAlignHorizontal>),
     
     Range_isize_(std::ops::Range<isize>),
     
@@ -52,6 +58,18 @@ pub enum TypesCoproduct {
     __pax_stdCOCOtypesCOCOColor(pax_example::pax_reexports::pax_std::types::Color),
     
     __pax_stdCOCOtypesCOCOStroke(pax_example::pax_reexports::pax_std::types::Stroke),
+    
+    __pax_stdCOCOtypesCOCOtextCOCOFont(pax_example::pax_reexports::pax_std::types::text::Font),
+    
+    __pax_stdCOCOtypesCOCOtextCOCOFontStyle(pax_example::pax_reexports::pax_std::types::text::FontStyle),
+    
+    __pax_stdCOCOtypesCOCOtextCOCOFontWeight(pax_example::pax_reexports::pax_std::types::text::FontWeight),
+    
+    __pax_stdCOCOtypesCOCOtextCOCOSizeWrapper(pax_example::pax_reexports::pax_std::types::text::SizeWrapper),
+    
+    __pax_stdCOCOtypesCOCOtextCOCOTextAlignHorizontal(pax_example::pax_reexports::pax_std::types::text::TextAlignHorizontal),
+    
+    __pax_stdCOCOtypesCOCOtextCOCOTextAlignVertical(pax_example::pax_reexports::pax_std::types::text::TextAlignVertical),
     
     __stdCOCOstringCOCOString(pax_example::pax_reexports::std::string::String),
     

--- a/pax-example/.pax/reexports.partial.rs
+++ b/pax-example/.pax/reexports.partial.rs
@@ -1,4 +1,9 @@
 pub mod pax_reexports { 
+	pub mod core {
+		pub mod option {
+			pub use core::option::Option;
+		}
+	}
 	pub use crate::Example;
 	pub mod fireworks {
 		pub use crate::fireworks::Fireworks;
@@ -16,10 +21,20 @@ pub mod pax_reexports {
 			pub use pax_std::primitives::Group;
 			pub use pax_std::primitives::Image;
 			pub use pax_std::primitives::Rectangle;
+			pub use pax_std::primitives::Text;
 		}
 		pub mod types {
 			pub use pax_std::types::Color;
 			pub use pax_std::types::Stroke;
+			pub mod text {
+				pub use pax_std::types::text::Font;
+				pub use pax_std::types::text::FontStyle;
+				pub use pax_std::types::text::FontWeight;
+				pub use pax_std::types::text::LinkStyle;
+				pub use pax_std::types::text::SizeWrapper;
+				pub use pax_std::types::text::TextAlignHorizontal;
+				pub use pax_std::types::text::TextAlignVertical;
+			}
 		}
 	}
 	pub mod std {

--- a/pax-example/src/words.pax
+++ b/pax-example/src/words.pax
@@ -1,7 +1,13 @@
 <Group>
+<Text text="Layer" width=300px height=300px/>
 <Image path="assets/images/pax-logo.png" id=logo />
 <Image path="assets/images/jpeg_test.jpg" id=card />
-
+<Text text="apple" width=300px height=300px />
+<Rectangle id=background />
+<Text text="carrot" width=300px height=300px/>
+<Image path="assets/images/pax-logo.png" id=logo />
+<Image path="assets/images/jpeg_test.jpg" id=card />
+<Text text="hello world" width=300px height=300px />
 <Rectangle id=background />
 </Group>
 

--- a/pax-message/src/lib.rs
+++ b/pax-message/src/lib.rs
@@ -20,7 +20,8 @@ pub enum NativeMessage {
     ScrollerCreate(AnyCreatePatch),
     ScrollerUpdate(ScrollerPatch),
     ScrollerDelete(Vec<u64>),
-    ImageLoad(ImagePatch)
+    ImageLoad(ImagePatch),
+    LayerAdd(LayerAddPatch)
     //FUTURE: native form controls
 }
 
@@ -30,7 +31,10 @@ pub enum NativeInterrupt {
     Click(ClickInterruptArgs),
     Scroll(ScrollInterruptArgs),
     Image(ImageLoadInterruptArgs),
+    AddedLayer(AddedLayerArgs),
 }
+
+
 
 #[derive(Deserialize)]
 #[repr(C)]
@@ -91,6 +95,11 @@ pub struct ScrollInterruptArgs {
     pub delta_y: f64,
 }
 
+#[derive(Deserialize)]
+#[repr(C)]
+pub struct AddedLayerArgs {
+    pub num_layers_added: u32,
+}
 
 #[derive(Default, Serialize)]
 #[repr(C)]
@@ -99,6 +108,7 @@ pub struct FramePatch {
     pub size_x: Option<f64>,
     pub size_y: Option<f64>,
     pub transform: Option<Vec<f64>>,
+    pub depth: Option<usize>,
 }
 
 
@@ -117,6 +127,7 @@ pub struct TextPatch {
     pub align_multiline: Option<TextAlignHorizontalMessage>,
     pub align_vertical: Option<TextAlignVerticalMessage>,
     pub align_horizontal: Option<TextAlignHorizontalMessage>,
+    pub depth: Option<usize>,
 }
 
 #[derive(Default, Serialize)]
@@ -180,6 +191,7 @@ pub struct ScrollerPatch {
     pub transform: Option<Vec<f64>>,
     pub scroll_x: Option<bool>,
     pub scroll_y: Option<bool>,
+    pub depth: Option<usize>,
 }
 
 
@@ -272,5 +284,11 @@ pub enum FontWeightMessage {
     Bold,
     ExtraBold,
     Black,
+}
+
+#[derive(Serialize)]
+#[repr(C)]
+pub struct LayerAddPatch {
+    pub num_layers_to_add: usize,
 }
 

--- a/pax-runtime-api/src/lib.rs
+++ b/pax-runtime-api/src/lib.rs
@@ -544,3 +544,39 @@ pub struct Timeline {
     pub frame_count: usize,
     pub is_playing: bool,
 }
+
+#[derive(Clone, PartialEq)]
+pub enum Layer {
+    Native,
+    Canvas
+}
+
+pub struct LayerInfo {
+    depth: usize,
+    layer: Layer,
+}
+
+impl LayerInfo {
+    pub fn new() -> Self {
+        LayerInfo {
+            depth: 0,
+            layer: Layer::Canvas,
+        }
+    }
+
+    pub fn get_depth(&mut self) -> usize {
+        self.depth
+    }
+
+    pub fn get_current_layer(&mut self) -> Layer {
+        self.layer.clone()
+    }
+    pub fn update_depth(&mut self, layer: Layer) {
+        if self.layer != layer {
+            if layer == Layer::Canvas {
+                self.depth += 1;
+            }
+            self.layer = layer.clone();
+        }
+    }
+}

--- a/pax-std/pax-std-primitives/src/frame.rs
+++ b/pax-std/pax-std-primitives/src/frame.rs
@@ -57,7 +57,7 @@ impl<R: 'static + RenderContext> RenderNode<R> for FrameInstance<R> {
         true
     }
 
-    fn compute_native_patches(&mut self, rtc: &mut RenderTreeContext<R>, computed_size: (f64, f64), transform_coeffs: Vec<f64>) {
+    fn compute_native_patches(&mut self, rtc: &mut RenderTreeContext<R>, computed_size: (f64, f64), transform_coeffs: Vec<f64>, depth: usize) {
 
         let mut new_message : FramePatch = Default::default();
         new_message.id_chain = rtc.get_id_chain(self.instance_id);
@@ -68,6 +68,21 @@ impl<R: 'static + RenderContext> RenderNode<R> for FrameInstance<R> {
         }
         let last_patch = self.last_patches.get_mut( &new_message.id_chain).unwrap();
         let mut has_any_updates = false;
+
+        let val = depth;
+        let is_new_value = match &last_patch.depth {
+            Some(cached_value) => {
+                !val.eq(cached_value)
+            },
+            None => {
+                true
+            }
+        };
+        if is_new_value {
+            new_message.depth = Some(val);
+            last_patch.depth = Some(val);
+            has_any_updates = true;
+        }
 
         let val = computed_size.0;
         let is_new_value = match &last_patch.size_x {
@@ -153,7 +168,7 @@ impl<R: 'static + RenderContext> RenderNode<R> for FrameInstance<R> {
         }
     }
 
-    fn handle_will_render(&mut self, rtc: &mut RenderTreeContext<R>, rc: &mut R) {
+    fn handle_will_render(&mut self, rtc: &mut RenderTreeContext<R>, rcs: &mut Vec<R>) {
         // construct a BezPath of this frame's bounds * its transform,
         // then pass that BezPath into rc.clip() [which pushes a clipping context to a piet-internal stack]
 
@@ -172,16 +187,18 @@ impl<R: 'static + RenderContext> RenderNode<R> for FrameInstance<R> {
         bez_path.close_path();
 
         let transformed_bez_path = transform * bez_path;
-        rc.save().unwrap(); //our "save point" before clipping — restored to in the did_render
-        rc.clip(transformed_bez_path);
-
+        for rc in rcs {
+            rc.save().unwrap(); //our "save point" before clipping — restored to in the did_render
+            rc.clip(transformed_bez_path.clone());
+        }
         let id_chain = rtc.get_id_chain(self.instance_id);
         (*rtc.runtime).borrow_mut().push_clipping_stack_id(id_chain);
     }
-    fn handle_did_render(&mut self, rtc: &mut RenderTreeContext<R>, rc: &mut R) {
-        //pop the clipping context from the stack
-        rc.restore().unwrap();
-
+    fn handle_did_render(&mut self, rtc: &mut RenderTreeContext<R>, _rcs: &mut Vec<R>) {
+        for rc in _rcs {
+            //pop the clipping context from the stack
+            rc.restore().unwrap();
+        }
         (*rtc.runtime).borrow_mut().pop_clipping_stack_id();
     }
 

--- a/pax-std/pax-std-primitives/src/image.rs
+++ b/pax-std/pax-std-primitives/src/image.rs
@@ -90,7 +90,7 @@ impl<R: 'static + RenderContext>  RenderNode<R> for ImageInstance<R> {
     }
 
 
-    fn compute_native_patches(&mut self, rtc: &mut RenderTreeContext<R>, computed_size: (f64, f64), transform_coeffs: Vec<f64>) {
+    fn compute_native_patches(&mut self, rtc: &mut RenderTreeContext<R>, computed_size: (f64, f64), transform_coeffs: Vec<f64>, depth : usize) {
         let mut new_message: ImagePatch = Default::default();
         new_message.id_chain = rtc.get_id_chain(self.instance_id);
         if !self.last_patches.contains_key(&new_message.id_chain) {


### PR DESCRIPTION
- Initialize layers (alternating canvas, native layer)
- measure depth on render pass
- if there are not enough layers, send a message to the chassis to add layers
- send an interrupt to the engine to load newly added layers
- draw new canvases depending on the depth
- send depth in native messages and add native elements to the correct native layer
- Stub out swift and punt on occlusion until necessary