### PR TITLE
Better memory management

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -963,30 +963,30 @@ dependencies = [
 
 [[package]]
 name = "pax-cartridge"
-version = "0.6.8"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ca14dbb5d0a55cded956835dae317f8b9e45db0de87f34b72abf6fa41c8d4c7"
+checksum = "947bb7304fc0259458e0743745d762fe0eaa9aaafc3aa0362e67ab69aa0b214e"
 dependencies = [
- "pax-core 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pax-properties-coproduct",
- "pax-runtime-api 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pax-std-primitives 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-runtime-api 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-std-primitives 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piet-common",
 ]
 
 [[package]]
 name = "pax-chassis-macos"
-version = "0.6.8"
+version = "0.6.0"
 dependencies = [
  "core-graphics",
  "flexbuffers",
  "lazy_static",
  "mut_static",
  "pax-cartridge",
- "pax-core 0.6.8",
- "pax-message 0.6.8",
+ "pax-core 0.6.0",
+ "pax-message 0.6.0",
  "pax-properties-coproduct",
- "pax-runtime-api 0.6.8",
+ "pax-runtime-api 0.6.0",
  "piet",
  "piet-coregraphics",
  "serde",
@@ -994,15 +994,15 @@ dependencies = [
 
 [[package]]
 name = "pax-chassis-web"
-version = "0.6.8"
+version = "0.6.0"
 dependencies = [
  "console_error_panic_hook",
  "js-sys",
  "pax-cartridge",
- "pax-core 0.6.8",
- "pax-message 0.6.8",
+ "pax-core 0.6.0",
+ "pax-message 0.6.0",
  "pax-properties-coproduct",
- "pax-runtime-api 0.6.8",
+ "pax-runtime-api 0.6.0",
  "piet",
  "piet-web",
  "serde",
@@ -1013,7 +1013,7 @@ dependencies = [
 
 [[package]]
 name = "pax-cli"
-version = "0.6.8"
+version = "0.6.0"
 dependencies = [
  "clap",
  "pax-compiler",
@@ -1021,7 +1021,7 @@ dependencies = [
 
 [[package]]
 name = "pax-compiler"
-version = "0.6.8"
+version = "0.6.0"
 dependencies = [
  "colored",
  "console_error_panic_hook",
@@ -1030,8 +1030,8 @@ dependencies = [
  "itertools",
  "kurbo",
  "lazy_static",
- "pax-message 0.6.8",
- "pax-runtime-api 0.6.8",
+ "pax-message 0.6.0",
+ "pax-runtime-api 0.6.0",
  "pest",
  "pest_derive",
  "portpicker",
@@ -1049,13 +1049,13 @@ dependencies = [
 
 [[package]]
 name = "pax-core"
-version = "0.6.8"
+version = "0.6.0"
 dependencies = [
  "kurbo",
  "lazy_static",
- "pax-message 0.6.8",
+ "pax-message 0.6.0",
  "pax-properties-coproduct",
- "pax-runtime-api 0.6.8",
+ "pax-runtime-api 0.6.0",
  "piet",
  "piet-common",
  "wasm-bindgen",
@@ -1063,15 +1063,15 @@ dependencies = [
 
 [[package]]
 name = "pax-core"
-version = "0.6.8"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53b101515324edb8267bdcbf4090e998608379b587d89bfad0c30bde3f84c1b2"
+checksum = "1d647b8b413b2ba717a3d97a96ad17258152c7a5d199bcc22adff6c632298116"
 dependencies = [
  "kurbo",
  "lazy_static",
- "pax-message 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-message 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "pax-properties-coproduct",
- "pax-runtime-api 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-runtime-api 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piet",
  "piet-common",
  "wasm-bindgen",
@@ -1079,28 +1079,28 @@ dependencies = [
 
 [[package]]
 name = "pax-lang"
-version = "0.6.8"
+version = "0.6.0"
 dependencies = [
  "pax-compiler",
- "pax-macro 0.6.8",
- "pax-message 0.6.8",
- "pax-runtime-api 0.6.8",
+ "pax-macro 0.6.0",
+ "pax-message 0.6.0",
+ "pax-runtime-api 0.6.0",
 ]
 
 [[package]]
 name = "pax-lang"
-version = "0.6.8"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db1fcec4e347d219ce967390f9f2d2a0b42910d74c82e403cbde136e302414af"
+checksum = "fbb569aebe83e5a8176825d16c5adc58790bed612356d7284a63c78ec1428141"
 dependencies = [
- "pax-macro 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pax-message 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pax-runtime-api 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-macro 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-message 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-runtime-api 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pax-macro"
-version = "0.6.8"
+version = "0.6.0"
 dependencies = [
  "litrs",
  "pest",
@@ -1116,9 +1116,9 @@ dependencies = [
 
 [[package]]
 name = "pax-macro"
-version = "0.6.8"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbaa9920cdcfbc824963ef6e67cd54b7206c582cf54fd14424736cf40446a6f2"
+checksum = "a603ef4a9afae1198b569e573190e808e6ca9c1bab854e0bc46a143a256d7f8a"
 dependencies = [
  "litrs",
  "pest",
@@ -1134,7 +1134,7 @@ dependencies = [
 
 [[package]]
 name = "pax-message"
-version = "0.6.8"
+version = "0.6.0"
 dependencies = [
  "serde",
  "serde_json",
@@ -1143,9 +1143,9 @@ dependencies = [
 
 [[package]]
 name = "pax-message"
-version = "0.6.8"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "172332cdfafc72c1c2a80e26dda9a11b7a0e8717d0cfa62d3593e2ce2ddf360b"
+checksum = "5640ba3984e4f2def943267b8adccd8d84e527041abfa2fb92d3e881d951d443"
 dependencies = [
  "serde",
  "serde_json",
@@ -1154,91 +1154,91 @@ dependencies = [
 
 [[package]]
 name = "pax-properties-coproduct"
-version = "0.6.8"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85f8c8900aeca9e532995a010affe9bd9725e26cc174ca0c64035a2abe42637d"
+checksum = "4160a94093482c562ad0278125135feda6c8b7231d31dfba146866a852d22237"
 dependencies = [
- "pax-runtime-api 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-runtime-api 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
 name = "pax-runtime-api"
-version = "0.6.8"
+version = "0.6.0"
 dependencies = [
  "kurbo",
  "lazy_static",
  "mut_static",
- "pax-message 0.6.8",
+ "pax-message 0.6.0",
  "uuid",
 ]
 
 [[package]]
 name = "pax-runtime-api"
-version = "0.6.8"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b65a6c1e39bbccb928e14370102ca078e5654f0adeaddfc2e6fa3aacd74692d"
+checksum = "a6996c82d72bddb7f1b784373e9b48fa020916ef71dd2a0d64e6a8f60814e464"
 dependencies = [
  "kurbo",
  "lazy_static",
  "mut_static",
- "pax-message 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-message 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid",
 ]
 
 [[package]]
 name = "pax-std"
-version = "0.6.8"
+version = "0.6.0"
 dependencies = [
  "kurbo",
  "lazy_static",
  "pax-compiler",
- "pax-lang 0.6.8",
- "pax-message 0.6.8",
- "pax-runtime-api 0.6.8",
+ "pax-lang 0.6.0",
+ "pax-message 0.6.0",
+ "pax-runtime-api 0.6.0",
  "piet",
  "serde_json",
 ]
 
 [[package]]
 name = "pax-std"
-version = "0.6.8"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8199c8b7e6d9a80e9c542c2968fb2f5a311c752f45c83a2a7da2857d4aa7b97"
+checksum = "fad24c86c59724e22915238c19a6f045427a71642a5b4b9ed77aaf035fc310c7"
 dependencies = [
  "kurbo",
  "lazy_static",
- "pax-lang 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pax-message 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pax-runtime-api 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-lang 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-message 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-runtime-api 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piet",
 ]
 
 [[package]]
 name = "pax-std-primitives"
-version = "0.6.8"
+version = "0.6.0"
 dependencies = [
  "kurbo",
- "pax-core 0.6.8",
- "pax-lang 0.6.8",
- "pax-message 0.6.8",
- "pax-runtime-api 0.6.8",
- "pax-std 0.6.8",
+ "pax-core 0.6.0",
+ "pax-lang 0.6.0",
+ "pax-message 0.6.0",
+ "pax-runtime-api 0.6.0",
+ "pax-std 0.6.0",
  "piet",
  "piet-common",
 ]
 
 [[package]]
 name = "pax-std-primitives"
-version = "0.6.8"
+version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38ae26b8fdab3bd1b1fd8d2900b5cdd699f6fca26ff39eb660981d0402178044"
+checksum = "71f8431194ad4cf6c59718ee0b354c45c8f1d92a843dc2fdcc128a6bac032f2c"
 dependencies = [
  "kurbo",
- "pax-core 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pax-lang 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pax-message 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pax-runtime-api 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
- "pax-std 0.6.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-core 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-lang 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-message 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-runtime-api 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-std 0.6.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "piet",
  "piet-common",
 ]

--- a/pax-chassis-web/src/lib.rs
+++ b/pax-chassis-web/src/lib.rs
@@ -362,11 +362,13 @@ impl PaxChassisWeb {
                     topmost_node.dispatch_context_menu(args_context_menu);
                 }
             }
-        }
+        };
+
     }
 
     pub fn tick(&mut self) -> String {
         let message_queue = self.engine.borrow_mut().tick(&mut self.drawing_contexts);
+
         //Note that this approach likely carries some CPU overhead, but may be suitable.
         //See zb lab journal `On robust message-passing to web` May 11 2022
         serde_json::to_string(&message_queue).unwrap()

--- a/pax-core/src/component.rs
+++ b/pax-core/src/component.rs
@@ -5,7 +5,7 @@ use std::collections::HashMap;
 use piet_common::RenderContext;
 
 use pax_properties_coproduct::{PropertiesCoproduct, TypesCoproduct};
-use crate::{RenderNode, RenderNodePtrList, RenderTreeContext, HandlerRegistry, InstantiationArgs, RenderNodePtr, Runtime, LifecycleNode, TabCache};
+use crate::{RenderNode, RenderNodePtrList, RenderTreeContext, HandlerRegistry, InstantiationArgs, RenderNodePtr, Runtime, LifecycleNode};
 
 use pax_runtime_api::{Timeline, Transform2D, Size2D, PropertyInstance, Layer};
 

--- a/pax-core/src/conditional.rs
+++ b/pax-core/src/conditional.rs
@@ -2,7 +2,7 @@ use std::cell::RefCell;
 use std::rc::Rc;
 
 use piet_common::RenderContext;
-use crate::{HandlerRegistry, ComponentInstance, TabCache, RenderNode, RenderNodePtr, RenderNodePtrList, RenderTreeContext, InstantiationArgs};
+use crate::{HandlerRegistry, ComponentInstance, RenderNode, RenderNodePtr, RenderNodePtrList, RenderTreeContext, InstantiationArgs};
 use pax_runtime_api::{Layer, PropertyInstance, PropertyLiteral, Size2D, Transform2D};
 use pax_properties_coproduct::{PropertiesCoproduct, TypesCoproduct};
 

--- a/pax-core/src/declarative_macros.rs
+++ b/pax-core/src/declarative_macros.rs
@@ -7,30 +7,31 @@
 #[macro_export]
 macro_rules! unsafe_unwrap {
     ($source_enum:expr, $enum_type:ty, $target_type:ty) => {{
-        fn unwrap_impl<T, U>(source_enum: T) -> (U, *mut T) {
+        fn unwrap_impl<T, U: Default>(source_enum: T) -> U {
             let size_of_enum = std::mem::size_of::<T>();
             let size_of_target = std::mem::size_of::<U>();
             let align_of_enum = std::mem::align_of::<T>();
 
-            assert!(size_of_target <= size_of_enum, "The size_of target_type must be less than or equal to the size_of enum_type.");
+            assert!(size_of_target < size_of_enum, "The size_of target_type must be less than the size_of enum_type.");
 
-            let boxed_enum = Box::new(source_enum);
-            let enum_ptr = Box::into_raw(boxed_enum);
-            let ptr_to_text = unsafe { ((enum_ptr as *const u8).add(align_of_enum) as *const U) };
-            let target_copy = unsafe { ptr_to_text.read() };
+            let mut boxed_enum = Box::new(source_enum);
+            let mut default_value = U::default();
 
-            (target_copy, enum_ptr)
+            let target = unsafe {
+                let enum_ptr = Box::into_raw(boxed_enum);
+                let target_ptr = (enum_ptr as *mut u8).add(align_of_enum) as *mut U;
+
+                std::mem::swap(&mut *target_ptr, &mut default_value);
+
+                // We no longer need the boxed enum, so it can be safely dropped.
+                // Note that because the value inside the enum variant was replaced with a default value,
+                // dropping this box does not drop the original value.
+                drop(Box::from_raw(enum_ptr));
+
+                default_value
+            };
+            target
         }
         unwrap_impl::<$enum_type, $target_type>($source_enum)
-    }};
-}
-
-#[macro_export]
-macro_rules! unsafe_cleanup {
-    ($raw_ptr:expr, $type:ty) => {{
-        unsafe {
-            let _boxed = Box::from_raw($raw_ptr as *mut $type);
-            // The Box is immediately dropped here, deallocating the memory.
-        }
     }};
 }

--- a/pax-core/src/declarative_macros.rs
+++ b/pax-core/src/declarative_macros.rs
@@ -7,21 +7,30 @@
 #[macro_export]
 macro_rules! unsafe_unwrap {
     ($source_enum:expr, $enum_type:ty, $target_type:ty) => {{
-        fn unwrap_impl<T, U>(source_enum: T) -> U {
+        fn unwrap_impl<T, U>(source_enum: T) -> (U, *mut T) {
             let size_of_enum = std::mem::size_of::<T>();
             let size_of_target = std::mem::size_of::<U>();
             let align_of_enum = std::mem::align_of::<T>();
 
-            assert!(size_of_target < size_of_enum, "The size_of target_type must be less than the size_of enum_type.");
+            assert!(size_of_target <= size_of_enum, "The size_of target_type must be less than or equal to the size_of enum_type.");
 
             let boxed_enum = Box::new(source_enum);
-            let target = unsafe {
-                let enum_ptr = Box::into_raw(boxed_enum);
-                let ptr_to_text = ((enum_ptr as *const u8).add(align_of_enum) as *const U);
-                ptr_to_text.read()
-            };
-            target
+            let enum_ptr = Box::into_raw(boxed_enum);
+            let ptr_to_text = unsafe { ((enum_ptr as *const u8).add(align_of_enum) as *const U) };
+            let target_copy = unsafe { ptr_to_text.read() };
+
+            (target_copy, enum_ptr)
         }
         unwrap_impl::<$enum_type, $target_type>($source_enum)
+    }};
+}
+
+#[macro_export]
+macro_rules! unsafe_cleanup {
+    ($raw_ptr:expr, $type:ty) => {{
+        unsafe {
+            let _boxed = Box::from_raw($raw_ptr as *mut $type);
+            // The Box is immediately dropped here, deallocating the memory.
+        }
     }};
 }

--- a/pax-core/src/rendering.rs
+++ b/pax-core/src/rendering.rs
@@ -161,26 +161,6 @@ impl TransformAndBounds {
     }
 }
 
-/// "Transform And Bounds" — a helper struct for storing necessary data for event propagation and ray casting
-pub struct TabCache<R: 'static + RenderContext> {
-    pub tabs: HashMap<Vec<u64>, TransformAndBounds>,
-    pub parents: HashMap<Vec<u64>, Option<RenderNodePtr<R>>>,
-}
-
-impl<R: 'static + RenderContext> TabCache<R> {
-    pub fn new() -> Self {
-        Self {
-            tabs: HashMap::new(),
-            parents: HashMap::new(),
-        }
-    }
-
-    pub fn clear(&mut self) {
-        self.tabs = HashMap::new();
-        self.parents = HashMap::new();
-    }
-}
-
 /// The base trait for a RenderNode, representing any node that can
 /// be rendered by the engine.
 /// T: a member of PropertiesCoproduct, representing the type of the set of properites

--- a/pax-core/src/repeat.rs
+++ b/pax-core/src/repeat.rs
@@ -6,7 +6,7 @@ use std::ops::Deref;
 
 
 use piet_common::RenderContext;
-use crate::{ComponentInstance, TabCache, RenderNode, RenderNodePtr, RenderNodePtrList, RenderTreeContext, InstantiationArgs, HandlerRegistry};
+use crate::{ComponentInstance, RenderNode, RenderNodePtr, RenderNodePtrList, RenderTreeContext, InstantiationArgs, HandlerRegistry};
 use pax_runtime_api::{Layer, log, PropertyInstance, PropertyLiteral, Size2D, Transform2D};
 use pax_properties_coproduct::{PropertiesCoproduct, TypesCoproduct};
 
@@ -64,7 +64,7 @@ impl<R: 'static + RenderContext> RenderNode<R> for RepeatInstance<R> {
 
 
         if self.next_frame_children.is_some() {
-            self.active_children = Rc::clone(self.next_frame_children.as_ref().unwrap());
+            self.active_children = self.next_frame_children.take().unwrap();
             self.next_frame_children = None;
         }
 
@@ -186,6 +186,7 @@ impl<R: 'static + RenderContext> RenderNode<R> for RepeatInstance<R> {
         self.cached_old_value_range = None;
         self.cached_old_value_vec = None;
     }
+
 }
 
 

--- a/pax-core/src/slot.rs
+++ b/pax-core/src/slot.rs
@@ -6,7 +6,7 @@ use std::collections::HashMap;
 use pax_properties_coproduct::{PropertiesCoproduct, TypesCoproduct};
 use piet_common::RenderContext;
 
-use crate::{InstantiationArgs, TabCache, RenderNodePtr, RenderNodePtrList, RenderNode, RenderTreeContext, HandlerRegistry};
+use crate::{InstantiationArgs, RenderNodePtr, RenderNodePtrList, RenderNode, RenderTreeContext, HandlerRegistry};
 use pax_runtime_api::{PropertyInstance, Transform2D, Size2D, Layer};
 
 

--- a/pax-core/tests/declarative_macro_tests.rs
+++ b/pax-core/tests/declarative_macro_tests.rs
@@ -11,7 +11,7 @@ enum Fruit {
 fn test_unwrap_apple() {
     let fruit = Fruit::Apple("green".to_string());
     let expected_color = "green".to_string();
-    let unwrapped_color: String =
+    let (unwrapped_color, _ptr) =
         unsafe_unwrap!(fruit, Fruit, String);
     assert_eq!(unwrapped_color, expected_color);
 }
@@ -20,5 +20,5 @@ fn test_unwrap_apple() {
 #[should_panic(expected = "The size_of target_type must be less than the size_of enum_type.")]
 fn test_unwrap_invalid_size() {
     let fruit = Fruit::Apple("red".to_string());
-    let _unwrapped_fruit: Fruit = unsafe_unwrap!(fruit, Fruit, Fruit);
+    let (_unwrapped_fruit, _ptr) = unsafe_unwrap!(fruit, Fruit, Fruit);
 }

--- a/pax-std/pax-std-primitives/src/ellipse.rs
+++ b/pax-std/pax-std-primitives/src/ellipse.rs
@@ -3,7 +3,7 @@ use piet::{RenderContext};
 
 use pax_std::primitives::{Ellipse};
 use pax_std::types::ColorVariant;
-use pax_core::{Color, TabCache, RenderNode, RenderNodePtrList, RenderTreeContext, ExpressionContext, InstanceRegistry, HandlerRegistry, InstantiationArgs, RenderNodePtr, unsafe_unwrap};
+use pax_core::{Color, RenderNode, RenderNodePtrList, RenderTreeContext, ExpressionContext, InstanceRegistry, HandlerRegistry, InstantiationArgs, RenderNodePtr, unsafe_unwrap, unsafe_cleanup};
 use pax_core::pax_properties_coproduct::{PropertiesCoproduct, TypesCoproduct};
 use pax_runtime_api::{PropertyInstance, PropertyLiteral, Size, Transform2D, Size2D};
 
@@ -20,6 +20,7 @@ pub struct EllipseInstance<R: 'static + RenderContext> {
     pub properties: Rc<RefCell<Ellipse>>,
     pub size: Rc<RefCell<[Box<dyn PropertyInstance<Size>>; 2]>>,
     pub transform: Rc<RefCell<dyn PropertyInstance<Transform2D>>>,
+    cleanup_ptr: *mut PropertiesCoproduct,
 }
 
 impl<R: 'static + RenderContext>  RenderNode<R> for EllipseInstance<R> {
@@ -33,7 +34,7 @@ impl<R: 'static + RenderContext>  RenderNode<R> for EllipseInstance<R> {
     }
 
     fn instantiate(mut args: InstantiationArgs<R>) -> Rc<RefCell<Self>> where Self: Sized {
-        let properties = unsafe_unwrap!(args.properties, PropertiesCoproduct, Ellipse);
+        let (properties, ptr) = unsafe_unwrap!(args.properties, PropertiesCoproduct, Ellipse);
         let mut instance_registry = (*args.instance_registry).borrow_mut();
         let instance_id = instance_registry.mint_id();
         let ret = Rc::new(RefCell::new(EllipseInstance {
@@ -42,7 +43,7 @@ impl<R: 'static + RenderContext>  RenderNode<R> for EllipseInstance<R> {
             properties: Rc::new(RefCell::new(properties)),
             size: args.size.expect("Ellipse requires a size"),
             handler_registry: args.handler_registry,
-
+            cleanup_ptr: ptr
         }));
 
         instance_registry.register(instance_id, Rc::clone(&ret) as RenderNodePtr<R>);
@@ -137,5 +138,9 @@ impl<R: 'static + RenderContext>  RenderNode<R> for EllipseInstance<R> {
             rc.stroke(duplicate_transformed_bez_path, &properties.stroke.get().color.get().to_piet_color(), width);
         }
 
+    }
+
+    fn handle_will_unmount(&mut self, _rtc: &mut RenderTreeContext<R>) {
+        unsafe_cleanup!(self.cleanup_ptr);
     }
 }

--- a/pax-std/pax-std-primitives/src/frame.rs
+++ b/pax-std/pax-std-primitives/src/frame.rs
@@ -7,7 +7,7 @@ use std::collections::HashMap;
 use kurbo::BezPath;
 use piet::RenderContext;
 
-use pax_core::{RenderNode, TabCache, RenderNodePtrList, RenderTreeContext, RenderNodePtr, InstantiationArgs, HandlerRegistry};
+use pax_core::{RenderNode, RenderNodePtrList, RenderTreeContext, RenderNodePtr, InstantiationArgs, HandlerRegistry};
 use pax_core::pax_properties_coproduct::TypesCoproduct;
 use pax_runtime_api::{Transform2D, Size, PropertyInstance, PropertyLiteral, Size2D, Layer};
 use pax_message::{AnyCreatePatch, FramePatch};

--- a/pax-std/pax-std-primitives/src/group.rs
+++ b/pax-std/pax-std-primitives/src/group.rs
@@ -1,7 +1,7 @@
 use std::cell::RefCell;
 use std::rc::Rc;
 use piet_common::RenderContext;
-use pax_core::{HandlerRegistry, TabCache, InstanceRegistry, InstantiationArgs, RenderNode, RenderNodePtr, RenderNodePtrList, RenderTreeContext, TransformAndBounds};
+use pax_core::{HandlerRegistry, InstanceRegistry, InstantiationArgs, RenderNode, RenderNodePtr, RenderNodePtrList, RenderTreeContext, TransformAndBounds};
 use pax_core::pax_properties_coproduct::{PropertiesCoproduct, TypesCoproduct};
 
 use pax_runtime_api::{Transform2D, Size2D, PropertyInstance, Layer};

--- a/pax-std/pax-std-primitives/src/image.rs
+++ b/pax-std/pax-std-primitives/src/image.rs
@@ -3,7 +3,7 @@ use piet::{ImageFormat, InterpolationMode, RenderContext, Image as PietImage, Er
 use std::collections::HashMap;
 use pax_std::primitives::{Image};
 use pax_std::types::ColorVariant;
-use pax_core::{Color, TabCache, RenderNode, RenderNodePtrList, RenderTreeContext, ExpressionContext, InstanceRegistry, HandlerRegistry, InstantiationArgs, RenderNodePtr, unsafe_unwrap};
+use pax_core::{Color, RenderNode, RenderNodePtrList, RenderTreeContext, ExpressionContext, InstanceRegistry, HandlerRegistry, InstantiationArgs, RenderNodePtr, unsafe_unwrap};
 use pax_core::pax_properties_coproduct::{PropertiesCoproduct, TypesCoproduct};
 use pax_runtime_api::{PropertyInstance, PropertyLiteral, Size, Transform2D, Size2D, log};
 

--- a/pax-std/pax-std-primitives/src/path.rs
+++ b/pax-std/pax-std-primitives/src/path.rs
@@ -3,7 +3,7 @@ use piet::{RenderContext};
 
 use pax_std::primitives::{Path};
 use pax_std::types::{ColorVariant, CurveSegmentData, LineSegmentData, PathSegment};
-use pax_core::{Color, TabCache, RenderNode, RenderNodePtrList, RenderTreeContext, ExpressionContext, InstanceRegistry, HandlerRegistry, InstantiationArgs, RenderNodePtr, unsafe_unwrap};
+use pax_core::{Color, RenderNode, RenderNodePtrList, RenderTreeContext, ExpressionContext, InstanceRegistry, HandlerRegistry, InstantiationArgs, RenderNodePtr, unsafe_unwrap};
 use pax_core::pax_properties_coproduct::{PropertiesCoproduct, TypesCoproduct};
 use pax_runtime_api::{PropertyInstance, PropertyLiteral, Size, Transform2D, Size2D};
 

--- a/pax-std/pax-std-primitives/src/rectangle.rs
+++ b/pax-std/pax-std-primitives/src/rectangle.rs
@@ -3,7 +3,7 @@ use piet::{LinearGradient, RadialGradient, RenderContext};
 
 use pax_std::primitives::{Rectangle};
 use pax_std::types::{ColorVariant, Fill, RectangleCornerRadii};
-use pax_core::{Color, TabCache, RenderNode, RenderNodePtrList, RenderTreeContext, ExpressionContext, InstanceRegistry, HandlerRegistry, InstantiationArgs, RenderNodePtr, unsafe_unwrap};
+use pax_core::{Color, RenderNode, RenderNodePtrList, RenderTreeContext, ExpressionContext, InstanceRegistry, HandlerRegistry, InstantiationArgs, RenderNodePtr, unsafe_unwrap};
 use pax_core::pax_properties_coproduct::{PropertiesCoproduct, TypesCoproduct};
 use pax_runtime_api::{PropertyInstance, PropertyLiteral, Size, Transform2D, Size2D, Property};
 

--- a/pax-std/pax-std-primitives/src/scroller.rs
+++ b/pax-std/pax-std-primitives/src/scroller.rs
@@ -8,7 +8,7 @@ use std::borrow::Borrow;
 use kurbo::BezPath;
 use piet::RenderContext;
 
-use pax_core::{RenderNode, TabCache, RenderNodePtrList, RenderTreeContext, RenderNodePtr, InstantiationArgs, HandlerRegistry};
+use pax_core::{RenderNode, RenderNodePtrList, RenderTreeContext, RenderNodePtr, InstantiationArgs, HandlerRegistry};
 use pax_core::pax_properties_coproduct::TypesCoproduct;
 use pax_runtime_api::{Transform2D, Size, PropertyInstance, PropertyLiteral, Size2D};
 use pax_message::{AnyCreatePatch, ScrollerPatch};

--- a/pax-std/pax-std-primitives/src/text.rs
+++ b/pax-std/pax-std-primitives/src/text.rs
@@ -4,7 +4,7 @@ use std::rc::Rc;
 use std::collections::HashMap;
 use piet::{RenderContext};
 use pax_std::primitives::{Text};
-use pax_core::{ComputableTransform, TabCache, HandlerRegistry, InstantiationArgs, RenderNode, RenderNodePtr, RenderNodePtrList, RenderTreeContext, unsafe_unwrap};
+use pax_core::{ComputableTransform, HandlerRegistry, InstantiationArgs, RenderNode, RenderNodePtr, RenderNodePtrList, RenderTreeContext, unsafe_unwrap};
 use pax_core::pax_properties_coproduct::{PropertiesCoproduct, TypesCoproduct};
 use pax_message::{AnyCreatePatch, TextPatch, TextStyleMessage};
 use pax_runtime_api::{PropertyInstance, Transform2D, Size2D, PropertyLiteral, log, Layer, SizePixels};
@@ -300,8 +300,9 @@ impl<R: 'static + RenderContext>  RenderNode<R> for TextInstance<R> {
     }
 
     fn handle_will_unmount(&mut self, _rtc: &mut RenderTreeContext<R>) {
-        self.last_patches.clear();
+
         let id_chain = _rtc.get_id_chain(self.instance_id);
+        self.last_patches.remove(&id_chain).unwrap();
         (*_rtc.engine.runtime).borrow_mut().enqueue_native_message(
             pax_message::NativeMessage::TextDelete(id_chain)
         );


### PR DESCRIPTION
1. fix severe memory leak inside unsafe_unwrap!, using std::mem::swap to pack memory into a Rust-managed container, then dropping our Box when done
2. fix minor memory leaks via `Rc` cycles, using `Weak` instead of `Rc` when we know we're creating a cycle (e.g. keeping a pointer to a parent)