### PR TITLE
fixed - safari canvas focusability bug?

### DIFF
--- a/pax-chassis-web/pax-dev-harness-web/run-web.sh
+++ b/pax-chassis-web/pax-dev-harness-web/run-web.sh
@@ -18,7 +18,7 @@ if [ "$SHOULD_ALSO_RUN" = "true" ]; then
   yarn serve || (yarn && yarn serve)
 else
   # Build, with production webpack config
-  yarn build
+  yarn && yarn build
 
   # Clear old build and move to output directory
   rm -rf "$OUTPUT_PATH"

--- a/pax-chassis-web/pax-dev-harness-web/src/events/listeners.ts
+++ b/pax-chassis-web/pax-dev-harness-web/src/events/listeners.ts
@@ -18,9 +18,6 @@ function getMouseButton(event: MouseEvent) {
 
 
 export function setupEventListeners(chassis: any, layer: any) {
-    // Need to make the layer focusable it can receive keyboard events
-    layer.setAttribute('tabindex', '1000');
-    layer.focus();
 
     let lastPositions = new Map<number, {x: number, y: number}>();
     // @ts-ignore


### PR DESCRIPTION
A bit of a doozy...
It looks like there is a bug in safari connected to focusing and canvases. If you create a div with a canvas element inside, programmatically set the 'tabindex' to that div (making it focusable), and set .focus(). Then when you focus on the page, you trigger safari to infinitely redraw the canvas. My best guess is that there is some erroneous logic to trigger redraw on any ancestor's focus and perhaps? we are double triggering it to cause some sort of loop. I think that webpack-dev-server injected something else in the dom (probably that warning overlay) that takes focus away from the mount preventing us from triggering the infinite loop. Also this doesn't happen when there is nothing for the canvas to draw which is why it disappeared when we commented out drawing & clearing stuff.

Here is a minimal repro: https://pastebin.com/GnT2VSuP

Retro:
The reason we had these lines in the first place was to support keyboard events since it seems a regular div cannot just listen for them. In a previous configuration, this whole function was called on a native overlay layer (not a canvas/mount) and thus we never saw this issue (since it has no canvas children) but with the re-organization of the dom stuff, I moved it to attach the listeners to the mount instead. Thus resulting in us landing in this bug.

Further research:
It looks like there were changes to both canvas focusability logic and tabindex logic in a recent update to webkit (https://webkit.org/blog/13966/webkit-features-in-safari-16-4/)