### PR TITLE
Support negation in expressions and literals

### DIFF
--- a/pax-compiler/src/expressions.rs
+++ b/pax-compiler/src/expressions.rs
@@ -193,6 +193,8 @@ fn recurse_compile_literal_block<'a>(
                     ("anchor_y", "Size".to_string()),
                     ("skew_x", "Numeric".to_string()),
                     ("skew_y", "Numeric".to_string()),
+                    ("scale_x", "Size".to_string()),
+                    ("scale_y", "Size".to_string()),
                     ("rotate", "Rotation".to_string()),
                 ]);
 

--- a/pax-compiler/src/parsing.rs
+++ b/pax-compiler/src/parsing.rs
@@ -91,13 +91,13 @@ fn recurse_pratt_parse_to_string<'a>(
                     let unit = literal_number_unit.as_str();
 
                     if unit == "px" {
-                        format!("Size::Pixels({}.into()).into()", exp_bod)
+                        format!("Size::Pixels({}.into())", exp_bod)
                     } else if unit == "%" {
-                        format!("Size::Percent({}.into()).into()", exp_bod)
+                        format!("Size::Percent({}.into())", exp_bod)
                     } else if unit == "deg" {
-                        format!("Rotation::Degrees({}.into()).into()", exp_bod)
+                        format!("Rotation::Degrees({}.into())", exp_bod)
                     } else if unit == "rad" {
-                        format!("Rotation::Radians({}.into()).into()", exp_bod)
+                        format!("Rotation::Radians({}.into())", exp_bod)
                     } else {
                         unreachable!()
                     }
@@ -180,13 +180,13 @@ fn recurse_pratt_parse_to_string<'a>(
                         let unit = inner.next().unwrap().as_str();
 
                         if unit == "px" {
-                            format!("Size::Pixels({}.into()).into()", value)
+                            format!("Size::Pixels({}.into())", value)
                         } else if unit == "%" {
-                            format!("Size::Percent({}.into()).into()", value)
+                            format!("Size::Percent({}.into())", value)
                         } else if unit == "deg" {
-                            format!("Rotation::Degrees({}.into()).into()", value)
+                            format!("Rotation::Degrees({}.into())", value)
                         } else if unit == "rad" {
-                            format!("Rotation::Radians({}.into()).into()", value)
+                            format!("Rotation::Radians({}.into())", value)
                         } else {
                             unreachable!()
                         }
@@ -195,14 +195,14 @@ fn recurse_pratt_parse_to_string<'a>(
                         let mut inner = literal_kind.into_inner();
                         let value = inner.next().unwrap().as_str();
                         format!("Numeric::from({})", value)
-                    }
-                    // Rule::string => {
-                    //     //TODO: figure out string concatenation.  Might need to introduce another operator?  Or perhaps a higher-level string type, which supports addition-as-concatenation — like we do with Numeric
-                    //     literal_kind.as_str().to_string() + ".to_string()"
-                    // }
+                    },
+                    Rule::string => {
+                        //TODO: figure out string concatenation.  Might need to introduce another operator?  Or perhaps a higher-level string type, which supports addition-as-concatenation — like we do with Numeric
+                        literal_kind.as_str().to_string() + ".to_string()"
+                    },
                     _ => {
                         /* {literal_enum_value | literal_tuple_access | literal_tuple | string } */
-                        literal_kind.as_str().to_string() + ".try_into().unwrap()"
+                        literal_kind.as_str().to_string()
                     }
                 }
             },

--- a/pax-core/src/engine.rs
+++ b/pax-core/src/engine.rs
@@ -88,8 +88,8 @@ impl<R: 'static + RenderContext> PropertiesComputable<R> for CommonProperties {
         handle_vtable_update!(rtc, self.height, Size);
         handle_vtable_update!(rtc, self.transform, Transform2D);
         handle_vtable_update_optional!(rtc, self.rotate, Rotation);
-        handle_vtable_update_optional!(rtc, self.scale_x, Numeric);
-        handle_vtable_update_optional!(rtc, self.scale_y, Numeric);
+        handle_vtable_update_optional!(rtc, self.scale_x, Size);
+        handle_vtable_update_optional!(rtc, self.scale_y, Size);
         handle_vtable_update_optional!(rtc, self.skew_x, Numeric);
         handle_vtable_update_optional!(rtc, self.skew_y, Numeric);
         handle_vtable_update_optional!(rtc, self.anchor_x, Size);
@@ -857,14 +857,14 @@ impl<R: 'static + RenderContext> PaxEngine<R> {
 
             let scale = [
                 if let Some(ref val) = cp.scale_x {
-                    val.borrow().get().get_as_float()
+                    val.borrow().get().clone()
                 } else {
-                    1.0
+                    Size::Percent(pax_runtime_api::Numeric::from(100.0))
                 },
                 if let Some(ref val) = cp.scale_y {
-                    val.borrow().get().get_as_float()
+                    val.borrow().get().clone()
                 } else {
-                    1.0
+                    Size::Percent(pax_runtime_api::Numeric::from(100.0))
                 },
             ];
             desugared_transform2d.scale = Some(scale);

--- a/pax-core/src/rendering.rs
+++ b/pax-core/src/rendering.rs
@@ -428,7 +428,7 @@ impl ComputableTransform for Transform2D {
 
         //decompose vanilla affine matrix and pack into `Affine`
         let (scale_x, scale_y) = if let Some(scale) = self.scale {
-            (scale[0], scale[1])
+            (scale[0].expect_percent(), scale[1].expect_percent())
         } else {
             (1.0, 1.0)
         };


### PR DESCRIPTION
For example `<SomeElement scale_y=-100% scale_x={-100%} />`

Also minor clean up of expression type inference "`into` hell" with explicit type declarations where relevant, removing some extraneous `.into` cruft along the way.  This refactor also delivers adding px + percent in expressions, like `width={50% + 15px}` for the "CSS margin offset" use-case.

Also refactor scale units => percent with an `expect_percent` method.  Note this is a slight stylistic divergence from `SizePixels`, which might be worth retiring at some point in favor of `Size` + `expect_pixels`.