### PR TITLE
Add RGB and HSL web support

### DIFF
--- a/pax-chassis-web/interface/public/pax-chassis-web-interface.js
+++ b/pax-chassis-web/interface/public/pax-chassis-web-interface.js
@@ -704,10 +704,20 @@ var Pax = (() => {
           if (style.fill.Rgba != null) {
             let p = style.fill.Rgba;
             newValue = `rgba(${p[0] * 255},${p[1] * 255},${p[2] * 255},${p[3] * 255})`;
-          } else {
+          } else if (style.fill.Hsla != null) {
             let p = style.fill.Hsla;
             newValue = `hsla(${p[0] * 255},${p[1] * 255},${p[2] * 255},${p[3] * 255})`;
+          } else if (style.fill.Rgb != null) {
+            let p = style.fill.Rgb;
+            newValue = `rgb(${p[0] * 255},${p[1] * 255},${p[2] * 255})`;
+          } else if (style.fill.Hsl != null) {
+            let p = style.fill.Hsl;
+            newValue = `hsl(${p[0] * 255},${p[1] * 255},${p[2] * 255})`;
+          } else {
+            console.log("unsupported color type!");
+            newValue = `rgb(255, 0, 255)`;
           }
+
           textChild.style.color = newValue;
         }
         if (style.font_size) {

--- a/pax-chassis-web/interface/public/pax-chassis-web-interface.js
+++ b/pax-chassis-web/interface/public/pax-chassis-web-interface.js
@@ -714,10 +714,8 @@ var Pax = (() => {
             let p = style.fill.Hsl;
             newValue = `hsl(${p[0] * 255},${p[1] * 255},${p[2] * 255})`;
           } else {
-            console.log("unsupported color type!");
-            newValue = `rgb(255, 0, 255)`;
+            throw new TypeError("Unsupported Color Format");
           }
-
           textChild.style.color = newValue;
         }
         if (style.font_size) {

--- a/pax-chassis-web/interface/src/classes/native-element-pool.ts
+++ b/pax-chassis-web/interface/src/classes/native-element-pool.ts
@@ -140,13 +140,22 @@ export class NativeElementPool {
             }
             if (style.fill) {
                 let newValue = "";
-                if(style.fill.Rgba != null) {
+                if (style.fill.Rgba != null) {
                     let p = style.fill.Rgba;
-                    newValue = `rgba(${p[0]! * 255.0},${p[1]! * 255.0},${p[2]! * 255.0},${p[3]! * 255.0})`;
+                    newValue = `rgba(${p[0] * 255},${p[1] * 255},${p[2] * 255},${p[3] * 255})`;
+                } else if (style.fill.Hsla != null) {
+                    let p = style.fill.Hsla;
+                    newValue = `hsla(${p[0] * 255},${p[1] * 255},${p[2] * 255},${p[3] * 255})`;
+                } else if (style.fill.Rgb != null) {
+                    let p = style.fill.Rgb;
+                    newValue = `rgb(${p[0] * 255},${p[1] * 255},${p[2] * 255})`;
+                } else if (style.fill.Hsl != null) {
+                    let p = style.fill.Hsl;
+                    newValue = `hsl(${p[0] * 255},${p[1] * 255},${p[2] * 255})`;
                 } else {
-                    let p = style.fill.Hsla!;
-                    newValue = `hsla(${p[0]! * 255.0},${p[1]! * 255.0},${p[2]! * 255.0},${p[3]! * 255.0})`;
-                }
+                    console.log("unsupported color type!");
+                    newValue = `rgb(255, 0, 255)`;
+                }        
                 textChild.style.color = newValue;
             }
             if (style.font_size) {

--- a/pax-chassis-web/interface/src/classes/native-element-pool.ts
+++ b/pax-chassis-web/interface/src/classes/native-element-pool.ts
@@ -153,8 +153,7 @@ export class NativeElementPool {
                     let p = style.fill.Hsl;
                     newValue = `hsl(${p[0] * 255},${p[1] * 255},${p[2] * 255})`;
                 } else {
-                    console.log("unsupported color type!");
-                    newValue = `rgb(255, 0, 255)`;
+                    throw new TypeError("Unsupported Color Format");
                 }        
                 textChild.style.color = newValue;
             }

--- a/pax-chassis-web/interface/src/classes/text.ts
+++ b/pax-chassis-web/interface/src/classes/text.ts
@@ -248,4 +248,6 @@ export function getAlignItems(verticalAlignment: string): string {
 class ColorGroup {
     Hsla?: number[];
     Rgba?: number[];
+    Rgb?: number[];
+    Hsl?: number[];
 }


### PR DESCRIPTION
Added RGB and HSL text support on the web. Since color representation on the web is consistent it might be worth doing the translations for fill/text/links etc in the same place at some point, but I don't feel familiar enough with the code yet to dare try to do that :)