### PR TITLE
support `cargo run` on all pax-cli created projects and pax-example

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1752,12 +1752,12 @@ checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
 name = "pax-cli"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "clap",
  "colored",
  "nix",
- "pax-compiler 0.10.6",
+ "pax-compiler 0.10.7",
  "pax-language-server",
  "reqwest",
  "rustc_version",
@@ -1767,7 +1767,7 @@ dependencies = [
 
 [[package]]
 name = "pax-compiler"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "actix-files",
  "actix-rt",
@@ -1785,8 +1785,8 @@ dependencies = [
  "libc",
  "log",
  "nix",
- "pax-message 0.10.6",
- "pax-runtime-api 0.10.6",
+ "pax-message 0.10.7",
+ "pax-runtime-api 0.10.7",
  "pest",
  "pest_derive",
  "portpicker",
@@ -1807,9 +1807,9 @@ dependencies = [
 
 [[package]]
 name = "pax-compiler"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aa70cfc71e7b2c1ed800480debcfb497d81156bfaea3deb40be93362236eb5dd"
+checksum = "fce0d3c5d136a85752743a62158521252732c19b548c2abc43c4ff578e803884"
 dependencies = [
  "actix-files",
  "actix-rt",
@@ -1827,8 +1827,8 @@ dependencies = [
  "libc",
  "log",
  "nix",
- "pax-message 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "pax-runtime-api 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-message 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-runtime-api 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest",
  "pest_derive",
  "portpicker",
@@ -1849,12 +1849,12 @@ dependencies = [
 
 [[package]]
 name = "pax-core"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "kurbo",
- "pax-message 0.10.6",
+ "pax-message 0.10.7",
  "pax-properties-coproduct",
- "pax-runtime-api 0.10.6",
+ "pax-runtime-api 0.10.7",
  "piet",
  "piet-common",
  "wasm-bindgen",
@@ -1862,25 +1862,25 @@ dependencies = [
 
 [[package]]
 name = "pax-lang"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
- "pax-compiler 0.10.6",
+ "pax-compiler 0.10.7",
  "pax-macro",
- "pax-message 0.10.6",
- "pax-runtime-api 0.10.6",
+ "pax-message 0.10.7",
+ "pax-runtime-api 0.10.7",
 ]
 
 [[package]]
 name = "pax-language-server"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "865bcff8c41667d803583f8e7c092452ba8a5214af65a818623bde62f8fb360a"
+checksum = "f1e21e421367d505f1fb095a6ff4554df68343d71c41ec718250f6e02b6c8689"
 dependencies = [
  "dashmap",
  "lazy_static",
  "lsp-types",
  "once_cell",
- "pax-compiler 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-compiler 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "pest",
  "pest_derive",
  "phf 0.11.2",
@@ -1896,7 +1896,7 @@ dependencies = [
 
 [[package]]
 name = "pax-macro"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "litrs",
  "pest",
@@ -1912,7 +1912,7 @@ dependencies = [
 
 [[package]]
 name = "pax-message"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "serde",
  "serde_json",
@@ -1921,9 +1921,9 @@ dependencies = [
 
 [[package]]
 name = "pax-message"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed8407c8df80191a0479484177a1398c858f31128a0f3133ffad87551fb2f31"
+checksum = "78644a6a6f388fc9fae7164f978549c98ab64ab8566df8440235921bce7baf7c"
 dependencies = [
  "serde",
  "serde_json",
@@ -1932,58 +1932,58 @@ dependencies = [
 
 [[package]]
 name = "pax-properties-coproduct"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
- "pax-runtime-api 0.10.6",
+ "pax-runtime-api 0.10.7",
 ]
 
 [[package]]
 name = "pax-runtime-api"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "kurbo",
  "lazy_static",
  "mut_static",
- "pax-message 0.10.6",
+ "pax-message 0.10.7",
  "uuid",
 ]
 
 [[package]]
 name = "pax-runtime-api"
-version = "0.10.6"
+version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c53e7307e43dde5d37792e249a89a40edfef9b77786b4a8e8f1bb4e29c91374e"
+checksum = "eaf0a722c2876780ed6ce2de3cc9833b601b09394eefc56cc5690f5a3120c06c"
 dependencies = [
  "kurbo",
  "lazy_static",
  "mut_static",
- "pax-message 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "pax-message 0.10.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "uuid",
 ]
 
 [[package]]
 name = "pax-std"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "kurbo",
  "lazy_static",
- "pax-compiler 0.10.6",
+ "pax-compiler 0.10.7",
  "pax-lang",
- "pax-message 0.10.6",
- "pax-runtime-api 0.10.6",
+ "pax-message 0.10.7",
+ "pax-runtime-api 0.10.7",
  "piet",
  "serde_json",
 ]
 
 [[package]]
 name = "pax-std-primitives"
-version = "0.10.6"
+version = "0.10.7"
 dependencies = [
  "kurbo",
  "pax-core",
  "pax-lang",
- "pax-message 0.10.6",
- "pax-runtime-api 0.10.6",
+ "pax-message 0.10.7",
+ "pax-runtime-api 0.10.7",
  "pax-std",
  "piet",
  "piet-common",

--- a/pax-cartridge/Cargo.toml
+++ b/pax-cartridge/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-cartridge"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -10,8 +10,8 @@ description = "Static program definition container for Pax programs, intended to
 
 [dependencies]
 piet-common = "0.6.0"
-pax-core = {path = "../pax-core", version = "0.10.6"}
-pax-runtime-api = {path = "../pax-runtime-api", version = "0.10.6"}
-pax-properties-coproduct = {path = "../pax-properties-coproduct", version="0.10.6"}
-pax-std-primitives = {path = "../pax-std/pax-std-primitives", version = "0.10.6"}
+pax-core = {path = "../pax-core", version = "0.10.7"}
+pax-runtime-api = {path = "../pax-runtime-api", version = "0.10.7"}
+pax-properties-coproduct = {path = "../pax-properties-coproduct", version="0.10.7"}
+pax-std-primitives = {path = "../pax-std/pax-std-primitives", version = "0.10.7"}
 

--- a/pax-chassis-common/Cargo.toml
+++ b/pax-chassis-common/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-chassis-common"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 description = "Shared resources for Pax Chassis"
@@ -16,11 +16,11 @@ include = ["src/**/*","pax-swift-common/**/*"]
 [dependencies]
 piet = "0.6.0"
 piet-coregraphics = "0.6.0"
-pax-core = { path = "../pax-core", version="0.10.6" }
-pax-cartridge = {path="../pax-cartridge", version="0.10.6"}
-pax-message = {path = "../pax-message", version="0.10.6"}
-pax-runtime-api = {path = "../pax-runtime-api", version="0.10.6"}
-pax-properties-coproduct = {path="../pax-properties-coproduct", version="0.10.6"}
+pax-core = { path = "../pax-core", version="0.10.7" }
+pax-cartridge = {path="../pax-cartridge", version="0.10.7"}
+pax-message = {path = "../pax-message", version="0.10.7"}
+pax-runtime-api = {path = "../pax-runtime-api", version="0.10.7"}
+pax-properties-coproduct = {path="../pax-properties-coproduct", version="0.10.7"}
 lazy_static = "1.4.0"
 mut_static = "5.0.0"
 #be cautious about core-graphics' version number --

--- a/pax-chassis-ios/Cargo.toml
+++ b/pax-chassis-ios/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pax-chassis-ios"
 edition = "2021"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://pax.dev/"
@@ -13,7 +13,7 @@ name = "paxchassisios"
 crate-type = ["cdylib"]
 
 [dependencies]
-pax-chassis-common = {version = "0.10.6", path="../pax-chassis-common"}
+pax-chassis-common = {version = "0.10.7", path="../pax-chassis-common"}
 
 # The following empty [workspace] directive is a workaround to satisfy
 # a cargo workspace bug, as documented: https://github.com/rust-lang/cargo/issues/6745

--- a/pax-chassis-macos/Cargo.toml
+++ b/pax-chassis-macos/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "pax-chassis-macos"
 edition = "2021"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://pax.dev/"
@@ -15,12 +15,12 @@ crate-type = ["cdylib"]
 [dependencies]
 piet = "0.6.0"
 piet-coregraphics = "0.6.0"
-pax-chassis-common = { path = "../pax-chassis-common", version="0.10.6" }
-pax-core = { path = "../pax-core", version="0.10.6" }
-pax-cartridge = {path="../pax-cartridge", version="0.10.6"}
-pax-message = {path = "../pax-message", version="0.10.6"}
-pax-runtime-api = {path = "../pax-runtime-api", version="0.10.6"}
-pax-properties-coproduct = {path="../pax-properties-coproduct", version="0.10.6"}
+pax-chassis-common = { path = "../pax-chassis-common", version="0.10.7" }
+pax-core = { path = "../pax-core", version="0.10.7" }
+pax-cartridge = {path="../pax-cartridge", version="0.10.7"}
+pax-message = {path = "../pax-message", version="0.10.7"}
+pax-runtime-api = {path = "../pax-runtime-api", version="0.10.7"}
+pax-properties-coproduct = {path="../pax-properties-coproduct", version="0.10.7"}
 lazy_static = "1.4.0"
 mut_static = "5.0.0"
 #be cautious about core-graphics' version number --

--- a/pax-chassis-web/Cargo.toml
+++ b/pax-chassis-web/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-chassis-web"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -17,11 +17,11 @@ default = ["console_error_panic_hook"]
 [dependencies]
 piet = "0.6.0"
 piet-web = "0.6.0"
-pax-core = { path = "../pax-core", version="0.10.6" }
-pax-properties-coproduct = {path="../pax-properties-coproduct", version="0.10.6"}
-pax-cartridge = {path="../pax-cartridge", version="0.10.6"}
-pax-runtime-api = {path = "../pax-runtime-api", version="0.10.6"}
-pax-message = {path = "../pax-message", version="0.10.6"}
+pax-core = { path = "../pax-core", version="0.10.7" }
+pax-properties-coproduct = {path="../pax-properties-coproduct", version="0.10.7"}
+pax-cartridge = {path="../pax-cartridge", version="0.10.7"}
+pax-runtime-api = {path = "../pax-runtime-api", version="0.10.7"}
+pax-message = {path = "../pax-message", version="0.10.7"}
 
 wasm-bindgen = {version = "0.2.80", features=["serde-serialize"]}
 serde = "1.0.159"

--- a/pax-cli/Cargo.toml
+++ b/pax-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-cli"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -12,12 +12,12 @@ description = "Command line interface tool for developing, packaging, and managi
 
 [dependencies]
 clap = "2.33.3"
-pax-compiler = {path = "../pax-compiler", version = "0.10.6"}
+pax-compiler = {path = "../pax-compiler", version = "0.10.7"}
 rustc_version = "0.4.0"
 tokio = { version = "1", features = ["full"] }
 colored = "2.0.0"
 reqwest = "0.11.18"
 signal-hook = "0.3"
 nix = "0.20.2"
-pax-language-server = {version = "0.10.6"}
+pax-language-server = {version = "0.10.7"}
 

--- a/pax-compiler/Cargo.toml
+++ b/pax-compiler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-compiler"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -31,8 +31,8 @@ tokio = { version = "1", features = ["full"] }
 reqwest = { version = "0.11.18", features = ["blocking"] }
 tar = "0.4"
 fs_extra = "1.3.0"
-pax-message = {version = "0.10.6", path="../pax-message"}
-pax-runtime-api = {version= "0.10.6", path="../pax-runtime-api"}
+pax-message = {version = "0.10.7", path="../pax-message"}
+pax-runtime-api = {version= "0.10.7", path="../pax-runtime-api"}
 pest = "2.6.0"
 pest_derive = "2.6.0"
 itertools = "0.10.5"

--- a/pax-compiler/new-project-template/Cargo.toml.template
+++ b/pax-compiler/new-project-template/Cargo.toml.template
@@ -2,6 +2,7 @@
 name = "CRATE_NAME"
 version = "VERSION_PLACEHOLDER"
 edition = "2021"
+default-run = "run"
 
 [dependencies]
 pax-lang = { version="VERSION_PLACEHOLDER" }
@@ -13,6 +14,10 @@ serde_json = {version = "1.0.95", optional = true}
 name = "parser"
 path = "src/lib.rs"
 required-features = ["parser"]
+
+[[bin]]
+name = "run"
+path = "bin/run.rs"
 
 [features]
 parser = ["pax-std/parser", "pax-lang/parser", "dep:serde_json", "dep:pax-compiler"]

--- a/pax-compiler/new-project-template/bin/run.rs
+++ b/pax-compiler/new-project-template/bin/run.rs
@@ -13,11 +13,10 @@ fn main() {
     };
 
     let current_dir = env::current_dir().expect("Failed to get current directory");
-    let parent_dir = current_dir.parent().expect("Failed to get parent directory");
 
     let status = Command::new("pax-cli")
         .args(&pax_args)
-        .current_dir(parent_dir)
+        .current_dir(current_dir)
         .status()
         .expect("Failed to execute pax-cli");
 

--- a/pax-compiler/new-project-template/bin/run.rs
+++ b/pax-compiler/new-project-template/bin/run.rs
@@ -1,0 +1,25 @@
+use std::process::Command;
+use std::env;
+
+fn main() {
+    let args: Vec<String> = env::args().skip(1).collect();
+
+    let pax_args = if args.is_empty() {
+        vec!["run", "--target=web"]
+    } else {
+        let mut extended_args = vec!["run"];
+        extended_args.extend(args.iter().map(|arg| arg.as_str()));
+        extended_args
+    };
+
+    let current_dir = env::current_dir().expect("Failed to get current directory");
+    let parent_dir = current_dir.parent().expect("Failed to get parent directory");
+
+    let status = Command::new("pax-cli")
+        .args(&pax_args)
+        .current_dir(parent_dir)
+        .status()
+        .expect("Failed to execute pax-cli");
+
+    std::process::exit(status.code().unwrap_or(1));
+}

--- a/pax-compiler/src/lib.rs
+++ b/pax-compiler/src/lib.rs
@@ -954,6 +954,8 @@ pub fn run_parser_binary(path: &str, process_child_ids: Arc<Mutex<Vec<u64>>>) ->
     let mut cmd = Command::new("cargo");
     cmd.current_dir(path)
         .arg("run")
+        .arg("--bin")
+        .arg("parser")
         .arg("--features")
         .arg("parser")
         .arg("--color")
@@ -999,7 +1001,7 @@ fn get_version_of_whitelisted_packages(path: &str) -> Result<String, &'static st
         .current_dir(path)
         .output()
         .expect("Failed to execute `cargo metadata`");
-
+    
     if !output.status.success() {
         eprintln!("{}", String::from_utf8_lossy(&output.stderr));
         panic!("Failed to get metadata from Cargo");
@@ -1043,6 +1045,7 @@ pub fn perform_build(ctx: &RunContext) -> Result<(), ()> {
     let pax_version = if ctx.is_libdev_mode {
         None
     } else {
+        println!("path:{}", &ctx.path);
         Some(get_version_of_whitelisted_packages(&ctx.path).unwrap())
     };
     clone_all_to_pkg_dir(&pax_dir, &pax_version, &ctx);

--- a/pax-compiler/src/lib.rs
+++ b/pax-compiler/src/lib.rs
@@ -1044,7 +1044,6 @@ pub fn perform_build(ctx: &RunContext) -> Result<(), ()> {
     let pax_version = if ctx.is_libdev_mode {
         None
     } else {
-        println!("path:{}", &ctx.path);
         Some(get_version_of_whitelisted_packages(&ctx.path).unwrap())
     };
     clone_all_to_pkg_dir(&pax_dir, &pax_version, &ctx);

--- a/pax-compiler/src/lib.rs
+++ b/pax-compiler/src/lib.rs
@@ -1000,7 +1000,7 @@ fn get_version_of_whitelisted_packages(path: &str) -> Result<String, &'static st
         .current_dir(path)
         .output()
         .expect("Failed to execute `cargo metadata`");
-    
+
     if !output.status.success() {
         eprintln!("{}", String::from_utf8_lossy(&output.stderr));
         panic!("Failed to get metadata from Cargo");

--- a/pax-core/Cargo.toml
+++ b/pax-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-core"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -14,9 +14,9 @@ description = "Core shared runtime and rendering engine for Pax"
 piet = "0.6.0"
 piet-common = "0.6.0"
 kurbo = "0.9.0"
-pax-properties-coproduct = { path="../pax-properties-coproduct", version="0.10.6" }
-pax-runtime-api = {path = "../pax-runtime-api", version="0.10.6"}
-pax-message = {path = "../pax-message", version="0.10.6"}
+pax-properties-coproduct = { path="../pax-properties-coproduct", version="0.10.7" }
+pax-runtime-api = {path = "../pax-runtime-api", version="0.10.7"}
+pax-message = {path = "../pax-message", version="0.10.7"}
 wasm-bindgen = {version = "0.2.30", features=["serde-serialize"]}
 
 

--- a/pax-example/Cargo.toml
+++ b/pax-example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-example"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -10,9 +10,9 @@ description = "Example and development app for the Pax monorepo and compiler"
 default-run = "run"
 
 [dependencies]
-pax-lang = { version="0.10.6", path=".pax/pkg/pax-lang" }
-pax-std = { version="0.10.6", path=".pax/pkg/pax-std" }
-pax-compiler = {version = "0.10.6", path=".pax/pkg/pax-compiler", optional = true}
+pax-lang = { version="0.10.7", path=".pax/pkg/pax-lang" }
+pax-std = { version="0.10.7", path=".pax/pkg/pax-std" }
+pax-compiler = {version = "0.10.7", path=".pax/pkg/pax-compiler", optional = true}
 serde_json = {version = "1.0.95", optional = true}
 
 [features]

--- a/pax-example/Cargo.toml
+++ b/pax-example/Cargo.toml
@@ -1,17 +1,18 @@
 [package]
 name = "pax-example"
-version = "0.10.6"
+version = "0.10.4"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
 homepage = "https://pax.dev/"
 repository = "https://www.github.com/pax-lang/pax"
 description = "Example and development app for the Pax monorepo and compiler"
+default-run = "run"
 
 [dependencies]
-pax-lang = { version="0.10.6", path=".pax/pkg/pax-lang" }
-pax-std = { version="0.10.6", path=".pax/pkg/pax-std" }
-pax-compiler = {version = "0.10.6", path=".pax/pkg/pax-compiler", optional = true}
+pax-lang = { version="0.10.4", path=".pax/pkg/pax-lang" }
+pax-std = { version="0.10.4", path=".pax/pkg/pax-std" }
+pax-compiler = {version = "0.10.4", path=".pax/pkg/pax-compiler", optional = true}
 serde_json = {version = "1.0.95", optional = true}
 
 [features]
@@ -21,3 +22,7 @@ parser = ["pax-std/parser", "pax-lang/parser", "dep:serde_json", "dep:pax-compil
 name = "parser"
 path = "src/lib.rs"
 required-features = ["parser"]
+
+[[bin]]
+name = "run"
+path = "bin/run.rs"

--- a/pax-example/Cargo.toml
+++ b/pax-example/Cargo.toml
@@ -10,9 +10,9 @@ description = "Example and development app for the Pax monorepo and compiler"
 default-run = "run"
 
 [dependencies]
-pax-lang = { version="0.10.4", path=".pax/pkg/pax-lang" }
-pax-std = { version="0.10.4", path=".pax/pkg/pax-std" }
-pax-compiler = {version = "0.10.4", path=".pax/pkg/pax-compiler", optional = true}
+pax-lang = { version="0.10.6", path=".pax/pkg/pax-lang" }
+pax-std = { version="0.10.6", path=".pax/pkg/pax-std" }
+pax-compiler = {version = "0.10.6", path=".pax/pkg/pax-compiler", optional = true}
 serde_json = {version = "1.0.95", optional = true}
 
 [features]

--- a/pax-example/Cargo.toml
+++ b/pax-example/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-example"
-version = "0.10.4"
+version = "0.10.6"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/pax-example/bin/run.rs
+++ b/pax-example/bin/run.rs
@@ -1,0 +1,24 @@
+use std::process::Command;
+use std::env;
+
+fn main() {
+    let args: Vec<String> = env::args().skip(1).collect();
+
+    let pax_args = if args.is_empty() {
+        vec!["run", "--target=web"]
+    } else {
+        let mut extended_args = vec!["run"];
+        extended_args.extend(args.iter().map(|arg| arg.as_str()));
+        extended_args
+    };
+
+    let current_dir = env::current_dir().expect("Failed to get current directory");
+
+    let status = Command::new("./pax")
+        .args(&pax_args)
+        .current_dir(current_dir)
+        .status()
+        .expect("Failed to execute pax-cli");
+
+    std::process::exit(status.code().unwrap_or(1));
+}

--- a/pax-lang/Cargo.toml
+++ b/pax-lang/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-lang"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -11,10 +11,10 @@ description = "Root import entry-point for using Pax in a Rust program"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pax-macro = {path="../pax-macro", version="0.10.6"}
-pax-message = {path="../pax-message", version="0.10.6"}
-pax-runtime-api = {path="../pax-runtime-api", version="0.10.6"}
-pax-compiler = {path="../pax-compiler", optional=true, version="0.10.6"}
+pax-macro = {path="../pax-macro", version="0.10.7"}
+pax-message = {path="../pax-message", version="0.10.7"}
+pax-runtime-api = {path="../pax-runtime-api", version="0.10.7"}
+pax-compiler = {path="../pax-compiler", optional=true, version="0.10.7"}
 
 [features]
 parser = ["dep:pax-compiler"]

--- a/pax-language-server/Cargo.toml
+++ b/pax-language-server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-language-server"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Warfa Jibril <warfa@pax.dev>"]
 license = "MIT OR Apache-2.0"
 homepage = "https://pax.dev/"
@@ -18,7 +18,7 @@ tokio = { version = "1.32.0", features = ["full"] }
 tower-lsp = "0.20.0"
 proc-macro2 = { version = "1.0", features = ["span-locations"] }
 quote = "1.0.33"
-pax-compiler = {version = "0.10.6", path="../pax-compiler"}
+pax-compiler = {version = "0.10.7", path="../pax-compiler"}
 pest = "2.7.4"
 pest_derive = "2.7.4"
 phf = { version = "0.11.2", features=["macros"] }

--- a/pax-macro/Cargo.toml
+++ b/pax-macro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-macro"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"

--- a/pax-message/Cargo.toml
+++ b/pax-message/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-message"
-version = "0.10.6"
+version = "0.10.7"
 edition = "2021"
 authors = ["Zack Brown <zack@pax.dev>"]
 license = "MIT OR Apache-2.0"

--- a/pax-properties-coproduct/Cargo.toml
+++ b/pax-properties-coproduct/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-properties-coproduct"
-version = "0.10.6"
+version = "0.10.7"
 
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
@@ -13,7 +13,7 @@ description = "Static container for program-variable data structures and polymor
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pax-runtime-api = {path = "../pax-runtime-api", version="0.10.6"}
+pax-runtime-api = {path = "../pax-runtime-api", version="0.10.7"}
 
 #
 #[patch.crates-io]

--- a/pax-runtime-api/Cargo.toml
+++ b/pax-runtime-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-runtime-api"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -15,4 +15,4 @@ kurbo = "0.9.0"
 lazy_static = "1.4.0"
 mut_static = "5.0.0"
 uuid = {version = "0.8", features = ["v4", "wasm-bindgen"]}
-pax-message = {version="0.10.6", path="../pax-message"}
+pax-message = {version="0.10.7", path="../pax-message"}

--- a/pax-std/Cargo.toml
+++ b/pax-std/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "pax-std"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -16,12 +16,12 @@ primitives_crate = "./pax-std-primitives"
 [dependencies]
 piet = "0.6.0"
 kurbo = "0.9.0"
-pax-lang = {path = "../pax-lang", version="0.10.6"}
-pax-message = {path = "../pax-message", version="0.10.6"}
+pax-lang = {path = "../pax-lang", version="0.10.7"}
+pax-message = {path = "../pax-message", version="0.10.7"}
 lazy_static = "1.4.0"
-pax-compiler = {path="../pax-compiler", optional = true, version="0.10.6"}
+pax-compiler = {path="../pax-compiler", optional = true, version="0.10.7"}
 serde_json = {version="1.0.95", optional = true}
-pax-runtime-api = {version="0.10.6", path="../pax-runtime-api"}
+pax-runtime-api = {version="0.10.7", path="../pax-runtime-api"}
 
 [features]
 parser = ["pax-lang/parser", "dep:pax-compiler", "dep:serde_json"]

--- a/pax-std/pax-std-primitives/Cargo.toml
+++ b/pax-std/pax-std-primitives/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pax-std-primitives"
-version = "0.10.6"
+version = "0.10.7"
 authors = ["Zack Brown <zack@pax.dev>"]
 edition = "2021"
 license = "MIT OR Apache-2.0"
@@ -12,11 +12,11 @@ description = "Primitives crate for Pax's standard library"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pax-lang = {path = "../../pax-lang", version="0.10.6"}
-pax-core = {path = "../../pax-core", version="0.10.6"}
-pax-std = {path = "../", version="0.10.6"}
-pax-runtime-api = {path = "../../pax-runtime-api", version="0.10.6"}
-pax-message = {path = "../../pax-message", version="0.10.6" }
+pax-lang = {path = "../../pax-lang", version="0.10.7"}
+pax-core = {path = "../../pax-core", version="0.10.7"}
+pax-std = {path = "../", version="0.10.7"}
+pax-runtime-api = {path = "../../pax-runtime-api", version="0.10.7"}
+pax-message = {path = "../../pax-message", version="0.10.7" }
 piet = "0.6.0"
 piet-common = "0.6.0"
 kurbo = "0.9.0"


### PR DESCRIPTION
This makes default cargo run work. 
includes 0.10.7 release which has a fix for assets folder that was breaking pax-cli create projects