### PR TITLE
fixed backwards compatability issue with new crates

### DIFF
--- a/pax-compiler/src/building/mod.rs
+++ b/pax-compiler/src/building/mod.rs
@@ -146,39 +146,46 @@ pub fn clone_all_to_pkg_dir(pax_dir: &PathBuf, pax_version: &Option<String>, ctx
                     pkg, pax_version
                 ));
 
-                let tarball_bytes = resp.bytes().expect("Failed to read tarball bytes");
+                if resp.status().is_success() {
+                    let tarball_bytes = resp.bytes().expect("Failed to read tarball bytes");
 
-                // Wrap the byte slice in a Cursor, so it can be used as a Read trait object.
-                let cursor = std::io::Cursor::new(&tarball_bytes[..]);
-
-                // Create a GzDecoder to handle the gzip layer.
-                let gz = GzDecoder::new(cursor);
-
-                // Pass the GzDecoder to tar::Archive.
-                let mut archive = Archive::new(gz);
-                // Iterate over the entries in the archive and modify the paths before extracting.
-                for entry_result in archive.entries().expect("Failed to read entries") {
-                    let mut entry = entry_result.expect("Failed to read entry");
-                    let path = match entry
-                        .path()
-                        .expect("Failed to get path")
-                        .components()
-                        .skip(1)
-                        .collect::<PathBuf>()
-                        .as_path()
-                        .to_owned()
-                    {
-                        path if path.to_string_lossy() == "" => continue, // Skip the root folder
-                        path => dest.join(path),
-                    };
-                    if entry.header().entry_type().is_dir() {
-                        fs::create_dir_all(&path).expect("Failed to create directory");
-                    } else {
-                        if let Some(parent) = path.parent() {
-                            fs::create_dir_all(&parent).expect("Failed to create parent directory");
+                    // Wrap the byte slice in a Cursor, so it can be used as a Read trait object.
+                    let cursor = std::io::Cursor::new(&tarball_bytes[..]);
+    
+                    // Create a GzDecoder to handle the gzip layer.
+                    let gz = GzDecoder::new(cursor);
+    
+                    // Pass the GzDecoder to tar::Archive.
+                    let mut archive = Archive::new(gz);
+                    // Iterate over the entries in the archive and modify the paths before extracting.
+                    for entry_result in archive.entries().expect("Failed to read entries") {
+                        let mut entry = entry_result.expect("Failed to read entry");
+                        let path = match entry
+                            .path()
+                            .expect("Failed to get path")
+                            .components()
+                            .skip(1)
+                            .collect::<PathBuf>()
+                            .as_path()
+                            .to_owned()
+                        {
+                            path if path.to_string_lossy() == "" => continue, // Skip the root folder
+                            path => dest.join(path),
+                        };
+                        if entry.header().entry_type().is_dir() {
+                            fs::create_dir_all(&path).expect("Failed to create directory");
+                        } else {
+                            if let Some(parent) = path.parent() {
+                                fs::create_dir_all(&parent).expect("Failed to create parent directory");
+                            }
+                            entry.unpack(&path).expect("Failed to unpack file");
                         }
-                        entry.unpack(&path).expect("Failed to unpack file");
                     }
+                } else {
+                    eprintln!(
+                        "Failed to download tarball for {} at version {}. Status: {}",
+                        pkg, pax_version, resp.status()
+                    );
                 }
             }
         }

--- a/pax-compiler/src/building/mod.rs
+++ b/pax-compiler/src/building/mod.rs
@@ -151,10 +151,10 @@ pub fn clone_all_to_pkg_dir(pax_dir: &PathBuf, pax_version: &Option<String>, ctx
 
                     // Wrap the byte slice in a Cursor, so it can be used as a Read trait object.
                     let cursor = std::io::Cursor::new(&tarball_bytes[..]);
-    
+
                     // Create a GzDecoder to handle the gzip layer.
                     let gz = GzDecoder::new(cursor);
-    
+
                     // Pass the GzDecoder to tar::Archive.
                     let mut archive = Archive::new(gz);
                     // Iterate over the entries in the archive and modify the paths before extracting.
@@ -176,7 +176,8 @@ pub fn clone_all_to_pkg_dir(pax_dir: &PathBuf, pax_version: &Option<String>, ctx
                             fs::create_dir_all(&path).expect("Failed to create directory");
                         } else {
                             if let Some(parent) = path.parent() {
-                                fs::create_dir_all(&parent).expect("Failed to create parent directory");
+                                fs::create_dir_all(&parent)
+                                    .expect("Failed to create parent directory");
                             }
                             entry.unpack(&path).expect("Failed to unpack file");
                         }
@@ -184,7 +185,9 @@ pub fn clone_all_to_pkg_dir(pax_dir: &PathBuf, pax_version: &Option<String>, ctx
                 } else {
                     eprintln!(
                         "Failed to download tarball for {} at version {}. Status: {}",
-                        pkg, pax_version, resp.status()
+                        pkg,
+                        pax_version,
+                        resp.status()
                     );
                 }
             }


### PR DESCRIPTION
Problem: 
New crates were created (e.g. `pax-chassis-common`). New versions of the cli are knowledgeable about these new crates. When a new version of a cli is used on an old project (one with older dependencies before the creation of the new crate). We try to fetch non-existent versions of these new crates. Resulting in a failed request that we then try to unzip. 

Causing this error:
`thread 'main' panicked at /home/ouz/.cargo/registry/src/index.crates.io-6f17d22bba15001f/pax-compiler-0.9.9/src/lib.rs:166:50:
Failed to read entry: Custom { kind: InvalidInput, error: "invalid gzip header" }`

Solution:
Instead check for this error and simply flag it since it will likely not affect the build process because old projects don't depend on these new crates.